### PR TITLE
DDF-475 Upgrade Mockito to version 1.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,7 +558,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This is one of three pull requests that need to be applied / rejected as a set. The other two are in ddf-catalog and ddf-security.

The need for this pull request is driven by Oracle JDK8 compatibility for ddf-catalog, which requires PowerMock to be upgraded to 1.5.4 for one particular call (related to constructor mocking with arguments).

PowerMock versions need to match Mockito versions (see Supported Versions table at https://code.google.com/p/powermock/wiki/MockitoUsage13). The upgrade to PowerMock 1.5.4 requires upgrading Mockito to at least 1.9.5 (which is the latest released version). Mockito version is in ddf-platform.

That (in turn) requires upgrading the PowerMock version in ddf-security to at least 1.5.4.

Unfortunately, travis-CI is going to show breakage because the changes aren't all being applied together.
