### PR TITLE
DDF-1174: JaCoCo not enabled anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,9 +156,6 @@
 
         <!-- Do NOT set karaf.data or karaf.base -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <!-- Needed to prevent problem with surefire when jacoco plug-in is not configured -->
-        <argLine></argLine>
     </properties>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -647,8 +647,10 @@
                                         <resources>
                                             <resource>
                                                 <directory>${basedir}/src/main/resources</directory>
-                                                <!--<include>config.adoc</include>-->
                                                 <filtering>true</filtering>
+                                                <includes>
+                                                    <include>**/*.adoc</include>
+                                                </includes>
                                             </resource>
                                         </resources>
                                     </configuration>


### PR DESCRIPTION
Removed default <argLine> property as it was disabling JaCoCo in all projects.

Reviewers: @pklinef, @shaundmorris

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/10)

<!-- Reviewable:end -->
