### PR TITLE
DDF-1184 Configuring PMD in DDF-Parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                         <dependency>
                             <groupId>ddf</groupId>
                             <artifactId>support-pmd</artifactId>
-                            <version>3.0.1-SNAPSHOT</version>
+                            <version>${project.version} </version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,47 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.4</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>ddf</groupId>
+                            <artifactId>support-pmd</artifactId>
+                            <version>3.0.1-SNAPSHOT</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <rulesets>
+                            <ruleset>
+                                basic.xml
+                            </ruleset>
+                            <ruleset>
+                                empty.xml
+                            </ruleset>
+                            <ruleset>
+                                sunsecure.xml
+                            </ruleset>
+                            <ruleset>
+                                unnecessary.xml
+                            </ruleset>
+                        </rulesets>
+                        <failOnViolation>
+                            false
+                        </failOnViolation>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>
+                                    check
+                                </goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.9.1</version>
                     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
     <groupId>ddf</groupId>
     <artifactId>ddf-parent</artifactId>
+    <!-- Must MANUALLY maven pmd plugin's support-pmd dependency version if this changes -->
     <version>3.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF Parent</name>
@@ -223,7 +224,8 @@
                         <dependency>
                             <groupId>ddf</groupId>
                             <artifactId>support-pmd</artifactId>
-                            <version>${project.version} </version>
+                            <!-- Must MANUALLY be updated if ddf-parent version changes -->
+                            <version>3.0.1-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/support-pmd/pom.xml
+++ b/support-pmd/pom.xml
@@ -12,28 +12,31 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-	
-	<parent>
-		<groupId>ddf</groupId>
-		<artifactId>ddf-parent</artifactId>
-		<version>3.0.1-SNAPSHOT</version>
-	</parent>
 
-	<artifactId>support-pmd</artifactId>
-	<name>DDF Support PMD</name>
-	<description>DDF Support PMD contains the ruleset file to use for source code analysis</description>
+    <parent>
+        <groupId>ddf</groupId>
+        <artifactId>ddf-parent</artifactId>
+        <version>3.0.1-SNAPSHOT</version>
+    </parent>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <artifactId>support-pmd</artifactId>
+    <name>DDF Support PMD</name>
+    <description>DDF Support PMD contains the ruleset file to use for source code analysis
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/support-pmd/pom.xml
+++ b/support-pmd/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>ddf</groupId>
+		<artifactId>ddf-parent</artifactId>
+		<version>3.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>support-pmd</artifactId>
+	<name>DDF Support PMD</name>
+	<description>DDF Support PMD contains the ruleset file to use for source code analysis</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/support-pmd/src/main/resources/basic.xml
+++ b/support-pmd/src/main/resources/basic.xml
@@ -1,0 +1,808 @@
+<?xml version="1.0"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<ruleset name="Basic"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+The Basic ruleset contains a collection of good practices which should be followed.
+  </description>
+
+	<rule name="JumbledIncrementer"
+    	  language="java"
+    	  since="1.0"
+          message="Avoid modifying an outer loop incrementer in an inner loop for update expression"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#JumbledIncrementer">
+     <description>
+Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+     </description>
+     <priority>3</priority>
+     <properties>
+         <property name="xpath">
+             <value>
+ <![CDATA[
+//ForStatement
+ [
+  ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
+  =
+  ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
+ ]
+ ]]>
+             </value>
+         </property>
+     </properties>
+     <example>
+ <![CDATA[
+public class JumbledIncrementerRule1 {
+	public void foo() {
+		for (int i = 0; i < 10; i++) {			// only references 'i'
+			for (int k = 0; k < 20; i++) {		// references both 'i' and 'k'
+				System.out.println("Hello");
+			}
+		}
+	}
+}
+ ]]>
+     </example>
+     </rule>
+
+    <rule name="ForLoopShouldBeWhileLoop"
+          language="java"
+          since="1.02"
+          message="This for loop could be simplified to a while loop"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ForLoopShouldBeWhileLoop">
+      <description>
+Some for loops can be simplified to while loops, this makes them more concise.
+      </description>
+      <priority>3</priority>
+    <properties>
+        <property name="xpath">
+            <value>
+                <![CDATA[
+//ForStatement
+ [count(*) > 1]
+ [not(LocalVariableDeclaration)]
+ [not(ForInit)]
+ [not(ForUpdate)]
+ [not(Type and Expression and Statement)]
+ ]]>
+            </value>
+        </property>
+    </properties>
+      <example>
+  <![CDATA[
+public class Foo {
+	void bar() {
+		for (;true;) true; // No Init or Update part, may as well be: while (true)
+	}
+}
+ ]]>
+      </example>
+    </rule>
+
+    <rule name="OverrideBothEqualsAndHashcode"
+          language="java"
+          since="0.4"
+          message="Ensure you override both equals() and hashCode()"
+          class="net.sourceforge.pmd.lang.java.rule.basic.OverrideBothEqualsAndHashcodeRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#OverrideBothEqualsAndHashcode">
+      <description>
+Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
+      </description>
+      <priority>3</priority>
+      <example>
+  <![CDATA[
+public class Bar {		// poor, missing a hashcode() method
+	public boolean equals(Object o) {
+      // do some comparison
+	}
+}
+
+public class Baz {		// poor, missing an equals() method
+	public int hashCode() {
+      // return some hash value
+	}
+}
+
+public class Foo {		// perfect, both methods provided
+	public boolean equals(Object other) {
+      // do some comparison
+	}
+	public int hashCode() {
+      // return some hash value
+	}
+}
+ ]]>
+      </example>
+    </rule>
+
+    <rule name="DoubleCheckedLocking"
+          language="java"
+          since="1.04"
+          message="Double checked locking is not thread safe in Java."
+          class="net.sourceforge.pmd.lang.java.rule.basic.DoubleCheckedLockingRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DoubleCheckedLocking">
+      <description>
+Partially created objects can be returned by the Double Checked Locking pattern when used in Java.
+An optimizing JRE may assign a reference to the baz variable before it creates the object the
+reference is intended to point to.
+
+For more details refer to: http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html
+or http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
+      </description>
+        <priority>1</priority>
+      <example>
+  <![CDATA[
+public class Foo {
+	Object baz;
+	Object bar() {
+		if (baz == null) { // baz may be non-null yet not fully created
+			synchronized(this) {
+				if (baz == null) {
+					baz = new Object();
+        		}
+      		}
+    	}
+		return baz;
+	}
+}
+ ]]>
+      </example>
+    </rule>
+
+    <rule name="ReturnFromFinallyBlock"
+          language="java"
+          since="1.05"
+          message="Avoid returning from a finally block"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ReturnFromFinallyBlock">
+      <description>
+Avoid returning from a finally block, this can discard exceptions.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//FinallyStatement//ReturnStatement
+]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+  <![CDATA[
+public class Bar {
+	public String foo() {
+		try {
+			throw new Exception( "My Exception" );
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			return "A. O. K."; // return not recommended here
+		}
+	}
+}
+]]>
+      </example>
+    </rule>
+
+    <rule name="UnconditionalIfStatement"
+          language="java"
+          since="1.5"
+          message="Do not use 'if' statements that are always true or always false"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#UnconditionalIfStatement">
+      <description>
+Do not use "if" statements whose conditionals are always true or always false.
+      </description>
+      <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+ <![CDATA[
+//IfStatement/Expression
+ [count(PrimaryExpression)=1]
+ /PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
+]]>
+                </value>
+            </property>
+        </properties>
+      <example>
+  <![CDATA[
+public class Foo {
+	public void close() {
+		if (true) {		// fixed conditional, not recommended
+			// ...
+		}
+	}
+}
+]]>
+      </example>
+    </rule>
+
+    <rule name="BooleanInstantiation"
+          since="1.2"
+          message="Avoid instantiating Boolean objects; reference Boolean.TRUE or Boolean.FALSE or call Boolean.valueOf() instead."
+          class="net.sourceforge.pmd.lang.java.rule.basic.BooleanInstantiationRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BooleanInstantiation">
+   <description>
+Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf() instead.
+   </description>
+      <priority>2</priority>
+   <example>
+   <![CDATA[
+Boolean bar = new Boolean("true");		// unnecessary creation, just reference Boolean.TRUE;
+Boolean buz = Boolean.valueOf(false);	// ...., just reference Boolean.FALSE;
+   ]]>
+   </example>
+   </rule>
+
+    <rule name="CollapsibleIfStatements"
+          language="java"
+          since="3.1"
+          message="These nested if statements could be combined"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CollapsibleIfStatements">
+      <description>
+Sometimes two consecutive 'if' statements can be consolidated by separating their conditions with a boolean short-circuit operator.
+      </description>
+      <priority>3</priority>
+      <properties>
+        <property name="xpath">
+            <value>
+                <![CDATA[
+//IfStatement[@Else='false']/Statement
+ /IfStatement[@Else='false']
+ |
+//IfStatement[@Else='false']/Statement
+ /Block[count(BlockStatement)=1]/BlockStatement
+  /Statement/IfStatement[@Else='false']]]>
+            </value>
+        </property>
+      </properties>
+      <example>
+  <![CDATA[
+void bar() {
+	if (x) {			// original implementation
+		if (y) {
+			// do stuff
+		}
+	}
+}
+
+void bar() {
+	if (x && y) {		// optimized implementation
+		// do stuff
+	}
+}
+ ]]>
+      </example>
+    </rule>
+
+	<rule name="ClassCastExceptionWithToArray"
+          language="java"
+          since="3.4"
+          message="This usage of the Collection.toArray() method will throw a ClassCastException."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ClassCastExceptionWithToArray">
+  <description>
+When deriving an array of a specific class from your Collection, one should provide an array of
+the same class as the parameter of the toArray() method. Doing otherwise you will will result
+in a ClassCastException.
+  </description>
+  <priority>3</priority>
+  <properties>
+    <property name="xpath">
+    <value>
+<![CDATA[
+//CastExpression[Type/ReferenceType/ClassOrInterfaceType[@Image !=
+"Object"]]/PrimaryExpression
+[
+ PrimaryPrefix/Name[ends-with(@Image, '.toArray')]
+ and
+ PrimarySuffix/Arguments[count(*) = 0]
+and
+count(PrimarySuffix) = 1
+]
+]]>
+    </value>
+    </property>
+  </properties>
+  <example>
+<![CDATA[
+Collection c = new ArrayList();
+Integer obj = new Integer(1);
+c.add(obj);
+
+    // this would trigger the rule (and throw a ClassCastException if executed)
+Integer[] a = (Integer [])c.toArray();
+
+   // this is fine and will not trigger the rule
+Integer[] b = (Integer [])c.toArray(new Integer[c.size()]);
+]]>
+  </example>
+</rule>
+
+
+<rule  name="AvoidDecimalLiteralsInBigDecimalConstructor"
+       language="java"
+       since="3.4"
+       message="Avoid creating BigDecimal with a decimal (float/double) literal. Use a String literal"
+       class="net.sourceforge.pmd.lang.rule.XPathRule"
+       externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidDecimalLiteralsInBigDecimalConstructor">
+  <description>
+One might assume that the result of "new BigDecimal(0.1)" is exactly equal to 0.1, but it is actually
+equal to .1000000000000000055511151231257827021181583404541015625.
+This is because 0.1 cannot be represented exactly as a double (or as a binary fraction of any finite
+length). Thus, the long value that is being passed in to the constructor is not exactly equal to 0.1,
+appearances notwithstanding.
+
+The (String) constructor, on the other hand, is perfectly predictable: 'new BigDecimal("0.1")' is
+exactly equal to 0.1, as one would expect.  Therefore, it is generally recommended that the
+(String) constructor be used in preference to this one.
+  </description>
+  <priority>3</priority>
+  <properties>
+    <property name="xpath">
+    <value>
+<![CDATA[
+//AllocationExpression
+[ClassOrInterfaceType[@Image="BigDecimal"]]
+[Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix
+    [
+        Literal[(not(ends-with(@Image,'"'))) and contains(@Image,".")]
+        or
+        Name[ancestor::Block/BlockStatement/LocalVariableDeclaration
+                [Type[PrimitiveType[@Image='double' or @Image='float']
+                      or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
+                /VariableDeclarator/VariableDeclaratorId/@Image = @Image
+            ]
+        or
+        Name[ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter
+                [Type[PrimitiveType[@Image='double' or @Image='float']
+                      or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
+                /VariableDeclaratorId/@Image = @Image
+            ]
+    ]
+]
+ ]]>
+    </value>
+    </property>
+  </properties>
+  <example>
+<![CDATA[
+BigDecimal bd = new BigDecimal(1.123);		// loss of precision, this would trigger the rule
+
+BigDecimal bd = new BigDecimal("1.123");   	// preferred approach
+
+BigDecimal bd = new BigDecimal(12);     	// preferred approach, ok for integer values
+]]>
+  </example>
+</rule>
+
+
+    <rule  name="MisplacedNullCheck"
+    	   language="java"
+           since="3.5"
+           message="The null check here is misplaced; if the variable is null there will be a NullPointerException"
+           class="net.sourceforge.pmd.lang.rule.XPathRule"
+           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#MisplacedNullCheck">
+      <description>
+The null check here is misplaced. If the variable is null a NullPointerException will be thrown.
+Either the check is useless (the variable will never be "null") or it is incorrect.
+      </description>
+      <priority>3</priority>
+      <properties>
+        <property name="xpath">
+        <value>
+    <![CDATA[
+//Expression
+    /*[self::ConditionalOrExpression or self::ConditionalAndExpression]
+    /descendant::PrimaryExpression/PrimaryPrefix
+    /Name[starts-with(@Image,
+        concat(ancestor::PrimaryExpression/following-sibling::EqualityExpression
+            [./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+            /PrimaryExpression/PrimaryPrefix
+            /Name[count(../../PrimarySuffix)=0]/@Image,".")
+        )
+     ]
+     [count(ancestor::ConditionalAndExpression/EqualityExpression
+            [@Image='!=']
+            [./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+            [starts-with(following-sibling::*/PrimaryExpression/PrimaryPrefix/Name/@Image,
+                concat(./PrimaryExpression/PrimaryPrefix/Name/@Image, '.'))]
+      ) = 0
+     ]
+    ]]>
+        </value>
+        </property>
+      </properties>
+      <example>
+    <![CDATA[
+public class Foo {
+	void bar() {
+		if (a.equals(baz) && a != null) {}
+		}
+}
+    ]]>
+      </example>
+      <example><![CDATA[
+public class Foo {
+	void bar() {
+		if (a.equals(baz) || a == null) {}
+	}
+}
+   ]]></example>
+    </rule>
+
+
+    <rule  name="AvoidThreadGroup"
+    	   language="java"
+           since="3.6"
+           message="Avoid using java.lang.ThreadGroup; it is not thread safe"
+           class="net.sourceforge.pmd.lang.rule.XPathRule"
+           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidThreadGroup"
+           typeResolution="true">
+      <description>
+Avoid using java.lang.ThreadGroup; although it is intended to be used in a threaded environment
+it contains methods that are not thread-safe.
+      </description>
+      <priority>3</priority>
+      <properties>
+        <property name="xpath">
+        <value>
+<![CDATA[
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.ThreadGroup')]|
+//PrimarySuffix[contains(@Image, 'getThreadGroup')]
+]]>
+        </value>
+        </property>
+      </properties>
+      <example>
+    <![CDATA[
+public class Bar {
+	void buz() {
+		ThreadGroup tg = new ThreadGroup("My threadgroup") ;
+		tg = new ThreadGroup(tg, "my thread group");
+		tg = Thread.currentThread().getThreadGroup();
+		tg = System.getSecurityManager().getThreadGroup();
+	}
+}
+    ]]>
+      </example>
+    </rule>
+
+    <rule name="BrokenNullCheck"
+          since="3.8"
+          message="Method call on object which may be null"
+          class="net.sourceforge.pmd.lang.java.rule.basic.BrokenNullCheckRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BrokenNullCheck">
+        <description>
+The null check is broken since it will throw a NullPointerException itself.
+It is likely that you used || instead of &amp;&amp; or vice versa.
+     </description>
+        <priority>2</priority>
+        <example>
+<![CDATA[
+public String bar(String string) {
+  // should be &&
+	if (string!=null || !string.equals(""))
+		return string;
+  // should be ||
+	if (string==null && string.equals(""))
+		return string;
+}
+        ]]>
+        </example>
+    </rule>
+
+    <rule name="BigIntegerInstantiation"
+          since="3.9"
+          message="Don't create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
+          class="net.sourceforge.pmd.lang.java.rule.basic.BigIntegerInstantiationRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BigIntegerInstantiation">
+  <description>
+Don't create instances of already existing BigInteger (BigInteger.ZERO, BigInteger.ONE) and
+for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN)
+  </description>
+  <priority>3</priority>
+  <example>
+<![CDATA[
+BigInteger bi = new BigInteger(1);		// reference BigInteger.ONE instead
+BigInteger bi2 = new BigInteger("0");	// reference BigInteger.ZERO instead
+BigInteger bi3 = new BigInteger(0.0);	// reference BigInteger.ZERO instead
+BigInteger bi4;
+bi4 = new BigInteger(0);				// reference BigInteger.ZERO instead
+]]>
+  </example>
+</rule>
+
+    <rule   name="AvoidUsingOctalValues"
+            since="3.9"
+            message="Do not start a literal by 0 unless it's an octal value"
+            class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingOctalValuesRule"
+            externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingOctalValues">
+    <description>
+    	<![CDATA[
+Integer literals should not start with zero since this denotes that the rest of literal will be
+interpreted as an octal value.
+    	]]>
+    </description>
+    <priority>3</priority>
+    <example>
+		    <![CDATA[
+int i = 012;	// set i with 10 not 12
+int j = 010;	// set j with 8 not 10
+k = i * j;		// set k with 80 not 120
+		    ]]>
+    </example>
+    </rule>
+
+    <rule   name="AvoidUsingHardCodedIP"
+            since="4.1"
+            message="Do not hard code the IP address ${variableName}"
+            class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingHardCodedIPRule"
+            externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingHardCodedIP">
+	    <description>
+	    	<![CDATA[
+Application with hard-coded IP addresses can become impossible to deploy in some cases.
+Externalizing IP adresses is preferable.
+	    	]]>
+	    </description>
+	    <priority>3</priority>
+	     <properties>
+            <property name="pattern" type="String" description="Regular Expression" value='^"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"$'/>
+        </properties>
+	    <example>
+	    <![CDATA[
+public class Foo {
+	private String ip = "127.0.0.1"; 	// not recommended
+}
+	    ]]>
+	    </example>
+    </rule>
+
+  <rule name="CheckResultSet"
+    	language="java"
+        since="4.1"
+        class="net.sourceforge.pmd.lang.java.rule.basic.CheckResultSetRule"
+        message="Always check the return of one of the navigation method (next,previous,first,last) of a ResultSet."
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckResultSet">
+        <description>
+            <![CDATA[
+Always check the return values of navigation methods (next, previous, first, last) of a ResultSet.
+If the value return is 'false', it should be handled properly.
+            ]]>
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+Statement stat = conn.createStatement();
+ResultSet rst = stat.executeQuery("SELECT name FROM person");
+rst.next(); 	// what if it returns false? bad form
+String firstName = rst.getString(1);
+
+Statement stat = conn.createStatement();
+ResultSet rst = stat.executeQuery("SELECT name FROM person");
+if (rst.next()) {	// result is properly examined and used
+    String firstName = rst.getString(1);
+	} else  {
+		// handle missing data
+}
+            ]]>
+        </example>
+    </rule>
+
+	<rule name="AvoidMultipleUnaryOperators"
+		  since="4.2"
+		  class="net.sourceforge.pmd.lang.java.rule.basic.AvoidMultipleUnaryOperatorsRule"
+		  message="Using multiple unary operators may be a bug, and/or is confusing."
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidMultipleUnaryOperators">
+        <description>
+            <![CDATA[
+The use of multiple unary operators may be problematic, and/or confusing.
+Ensure that the intended usage is not a bug, or consider simplifying the expression.
+            ]]>
+        </description>
+        <priority>2</priority>
+        <example>
+            <![CDATA[
+// These are typo bugs, or at best needlessly complex and confusing:
+int i = - -1;
+int j = + - +1;
+int z = ~~2;
+boolean b = !!true;
+boolean c = !!!true;
+
+// These are better:
+int i = 1;
+int j = -1;
+int z = 2;
+boolean b = true;
+boolean c = false;
+
+// And these just make your brain hurt:
+int i = ~-2;
+int j = -~7;
+            ]]>
+        </example>
+    </rule>
+
+  <rule name="ExtendsObject"
+  		language="java"
+        since="5.0"
+        message="No need to explicitly extend Object."
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ExtendsObject">
+    <description>No need to explicitly extend Object.</description>
+    <priority>4</priority>
+    <properties>
+       <property name="xpath">
+          <value>
+          <![CDATA[
+//ExtendsList/ClassOrInterfaceType[@Image='Object' or @Image='java.lang.Object']
+          ]]>
+          </value>
+       </property>
+    </properties>
+    <example>
+    <![CDATA[
+public class Foo extends Object { 	// not required
+}
+    ]]>
+    </example>
+  </rule>
+
+	<rule name="CheckSkipResult"
+	      language="java"
+	  	  since="5.0"
+          message="Check the value returned by the skip() method of an InputStream to see if the requested number of bytes has been skipped."
+          class="net.sourceforge.pmd.lang.java.rule.basic.CheckSkipResultRule"
+	  	  externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckSkipResult">
+        <description>The skip() method may skip a smaller number of bytes than requested. Check the returned value to find out if it was the case or not.</description>
+        <priority>3</priority>
+        <example>
+        <![CDATA[
+public class Foo {
+
+   private FileInputStream _s = new FileInputStream("file");
+
+   public void skip(int n) throws IOException {
+      _s.skip(n); // You are not sure that exactly n bytes are skipped
+   }
+
+   public void skipExactly(int n) throws IOException {
+      while (n != 0) {
+         long skipped = _s.skip(n);
+         if (skipped == 0)
+            throw new EOFException();
+         n -= skipped;
+      }
+   }
+        ]]>
+        </example>
+    </rule>
+
+	<rule name="AvoidBranchingStatementAsLastInLoop"
+	  	  since="5.0"
+		  class="net.sourceforge.pmd.lang.java.rule.basic.AvoidBranchingStatementAsLastInLoopRule"
+		  message="Avoid using a branching statement as the last in a loop."
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidBranchingStatementAsLastInLoop">
+        <description>
+            <![CDATA[
+Using a branching statement as the last part of a loop may be a bug, and/or is confusing.
+Ensure that the usage is not a bug, or consider using another approach.
+            ]]>
+        </description>
+        <priority>2</priority>
+        <example>
+            <![CDATA[
+  // unusual use of branching statement in a loop
+for (int i = 0; i < 10; i++) {
+	if (i*i <= 25) {
+		continue;
+	}
+	break;
+}
+
+  // this makes more sense...
+for (int i = 0; i < 10; i++) {
+	if (i*i > 25) {
+		break;
+	}
+}
+            ]]>
+        </example>
+    </rule>
+
+    <rule  name="DontCallThreadRun"
+           language="java"
+           since="4.3"
+           message="Don't call Thread.run() explicitly, use Thread.start()"
+           class="net.sourceforge.pmd.lang.rule.XPathRule"
+           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontCallThreadRun">
+      <description>
+Explicitly calling Thread.run() method will execute in the caller's thread of control.  Instead, call Thread.start() for the intended behavior.
+      </description>
+      <priority>4</priority>
+      <properties>
+        <property name="xpath">
+          <value>
+<![CDATA[
+//StatementExpression/PrimaryExpression
+[
+    PrimaryPrefix
+    [
+        ./Name[ends-with(@Image, '.run') or @Image = 'run']
+        and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
+        [../../../Type/ReferenceType[ClassOrInterfaceType/@Image = 'Thread']]
+        or (
+        ./AllocationExpression/ClassOrInterfaceType[@Image = 'Thread']
+        and ../PrimarySuffix[@Image = 'run'])
+    ]
+]
+]]>
+         </value>
+        </property>
+      </properties>
+      <example>
+<![CDATA[
+Thread t = new Thread();
+t.run();            // use t.start() instead
+new Thread().run(); // same violation
+]]>
+      </example>
+    </rule>
+
+  <rule  name="DontUseFloatTypeForLoopIndices"
+         language="java"
+         since="4.3"
+         message="Don't use floating point for loop indices. If you must use floating point, use double."
+         class="net.sourceforge.pmd.lang.rule.XPathRule"
+         externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontUseFloatTypeForLoopIndices">
+    <description>
+Don't use floating point for loop indices. If you must use floating point, use double
+unless you're certain that float provides enough precision and you have a compelling
+performance need (space or time).
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//ForStatement/ForInit/LocalVariableDeclaration
+/Type/PrimitiveType[@Image="float"]
+]]>
+       </value>
+      </property>
+    </properties>
+    <example>
+<![CDATA[
+public class Count {
+  public static void main(String[] args) {
+    final int START = 2000000000;
+    int count = 0;
+    for (float f = START; f < START + 50; f++)
+      count++;
+      //Prints 0 because (float) START == (float) (START + 50).
+      System.out.println(count);
+      //The termination test misbehaves due to floating point granularity.
+    }
+}
+]]>
+    </example>
+  </rule>
+
+</ruleset>

--- a/support-pmd/src/main/resources/basic.xml
+++ b/support-pmd/src/main/resources/basic.xml
@@ -17,6 +17,7 @@
     <description>
         The Basic ruleset contains a collection of good practices which should be followed.
     </description>
+    <exclude-pattern>.*/target/.*</exclude-pattern>
 
     <rule name="JumbledIncrementer"
           language="java"

--- a/support-pmd/src/main/resources/basic.xml
+++ b/support-pmd/src/main/resources/basic.xml
@@ -11,27 +11,28 @@
  *
  **/ -->
 <ruleset name="Basic"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <description>
-The Basic ruleset contains a collection of good practices which should be followed.
-  </description>
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        The Basic ruleset contains a collection of good practices which should be followed.
+    </description>
 
-	<rule name="JumbledIncrementer"
-    	  language="java"
-    	  since="1.0"
+    <rule name="JumbledIncrementer"
+          language="java"
+          since="1.0"
           message="Avoid modifying an outer loop incrementer in an inner loop for update expression"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#JumbledIncrementer">
-     <description>
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
-     </description>
-     <priority>3</priority>
-     <properties>
-         <property name="xpath">
-             <value>
- <![CDATA[
+        <description>
+            Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if
+            intentional.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //ForStatement
  [
   ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
@@ -39,11 +40,11 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
   ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
  ]
  ]]>
-             </value>
-         </property>
-     </properties>
-     <example>
- <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class JumbledIncrementerRule1 {
 	public void foo() {
 		for (int i = 0; i < 10; i++) {			// only references 'i'
@@ -54,8 +55,8 @@ public class JumbledIncrementerRule1 {
 	}
 }
  ]]>
-     </example>
-     </rule>
+        </example>
+    </rule>
 
     <rule name="ForLoopShouldBeWhileLoop"
           language="java"
@@ -63,14 +64,14 @@ public class JumbledIncrementerRule1 {
           message="This for loop could be simplified to a while loop"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ForLoopShouldBeWhileLoop">
-      <description>
-Some for loops can be simplified to while loops, this makes them more concise.
-      </description>
-      <priority>3</priority>
-    <properties>
-        <property name="xpath">
-            <value>
-                <![CDATA[
+        <description>
+            Some for loops can be simplified to while loops, this makes them more concise.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //ForStatement
  [count(*) > 1]
  [not(LocalVariableDeclaration)]
@@ -78,18 +79,18 @@ Some for loops can be simplified to while loops, this makes them more concise.
  [not(ForUpdate)]
  [not(Type and Expression and Statement)]
  ]]>
-            </value>
-        </property>
-    </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 	void bar() {
 		for (;true;) true; // No Init or Update part, may as well be: while (true)
 	}
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="OverrideBothEqualsAndHashcode"
@@ -98,12 +99,15 @@ public class Foo {
           message="Ensure you override both equals() and hashCode()"
           class="net.sourceforge.pmd.lang.java.rule.basic.OverrideBothEqualsAndHashcodeRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#OverrideBothEqualsAndHashcode">
-      <description>
-Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
-      </description>
-      <priority>3</priority>
-      <example>
-  <![CDATA[
+        <description>
+            Override both public boolean Object.equals(Object other), and public int
+            Object.hashCode(), or override neither. Even if you are inheriting a hashCode() from a
+            parent class, consider implementing hashCode and explicitly delegating to your
+            superclass.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
 public class Bar {		// poor, missing a hashcode() method
 	public boolean equals(Object o) {
       // do some comparison
@@ -125,7 +129,7 @@ public class Foo {		// perfect, both methods provided
 	}
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="DoubleCheckedLocking"
@@ -134,17 +138,20 @@ public class Foo {		// perfect, both methods provided
           message="Double checked locking is not thread safe in Java."
           class="net.sourceforge.pmd.lang.java.rule.basic.DoubleCheckedLockingRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DoubleCheckedLocking">
-      <description>
-Partially created objects can be returned by the Double Checked Locking pattern when used in Java.
-An optimizing JRE may assign a reference to the baz variable before it creates the object the
-reference is intended to point to.
+        <description>
+            Partially created objects can be returned by the Double Checked Locking pattern when
+            used in Java.
+            An optimizing JRE may assign a reference to the baz variable before it creates the
+            object the
+            reference is intended to point to.
 
-For more details refer to: http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html
-or http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
-      </description>
+            For more details refer to:
+            http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html
+            or http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
+        </description>
         <priority>1</priority>
-      <example>
-  <![CDATA[
+        <example>
+            <![CDATA[
 public class Foo {
 	Object baz;
 	Object bar() {
@@ -159,7 +166,7 @@ public class Foo {
 	}
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="ReturnFromFinallyBlock"
@@ -168,21 +175,21 @@ public class Foo {
           message="Avoid returning from a finally block"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ReturnFromFinallyBlock">
-      <description>
-Avoid returning from a finally block, this can discard exceptions.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Avoid returning from a finally block, this can discard exceptions.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //FinallyStatement//ReturnStatement
 ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Bar {
 	public String foo() {
 		try {
@@ -195,7 +202,7 @@ public class Bar {
 	}
 }
 ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="UnconditionalIfStatement"
@@ -204,14 +211,14 @@ public class Bar {
           message="Do not use 'if' statements that are always true or always false"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#UnconditionalIfStatement">
-      <description>
-Do not use "if" statements whose conditionals are always true or always false.
-      </description>
-      <priority>3</priority>
+        <description>
+            Do not use "if" statements whose conditionals are always true or always false.
+        </description>
+        <priority>3</priority>
         <properties>
             <property name="xpath">
                 <value>
- <![CDATA[
+                    <![CDATA[
 //IfStatement/Expression
  [count(PrimaryExpression)=1]
  /PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
@@ -219,8 +226,8 @@ Do not use "if" statements whose conditionals are always true or always false.
                 </value>
             </property>
         </properties>
-      <example>
-  <![CDATA[
+        <example>
+            <![CDATA[
 public class Foo {
 	public void close() {
 		if (true) {		// fixed conditional, not recommended
@@ -229,7 +236,7 @@ public class Foo {
 	}
 }
 ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="BooleanInstantiation"
@@ -237,17 +244,18 @@ public class Foo {
           message="Avoid instantiating Boolean objects; reference Boolean.TRUE or Boolean.FALSE or call Boolean.valueOf() instead."
           class="net.sourceforge.pmd.lang.java.rule.basic.BooleanInstantiationRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BooleanInstantiation">
-   <description>
-Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf() instead.
-   </description>
-      <priority>2</priority>
-   <example>
-   <![CDATA[
+        <description>
+            Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or
+            call Boolean.valueOf() instead.
+        </description>
+        <priority>2</priority>
+        <example>
+            <![CDATA[
 Boolean bar = new Boolean("true");		// unnecessary creation, just reference Boolean.TRUE;
 Boolean buz = Boolean.valueOf(false);	// ...., just reference Boolean.FALSE;
    ]]>
-   </example>
-   </rule>
+        </example>
+    </rule>
 
     <rule name="CollapsibleIfStatements"
           language="java"
@@ -255,25 +263,26 @@ Boolean buz = Boolean.valueOf(false);	// ...., just reference Boolean.FALSE;
           message="These nested if statements could be combined"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CollapsibleIfStatements">
-      <description>
-Sometimes two consecutive 'if' statements can be consolidated by separating their conditions with a boolean short-circuit operator.
-      </description>
-      <priority>3</priority>
-      <properties>
-        <property name="xpath">
-            <value>
-                <![CDATA[
+        <description>
+            Sometimes two consecutive 'if' statements can be consolidated by separating their
+            conditions with a boolean short-circuit operator.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //IfStatement[@Else='false']/Statement
  /IfStatement[@Else='false']
  |
 //IfStatement[@Else='false']/Statement
  /Block[count(BlockStatement)=1]/BlockStatement
   /Statement/IfStatement[@Else='false']]]>
-            </value>
-        </property>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 void bar() {
 	if (x) {			// original implementation
 		if (y) {
@@ -288,25 +297,27 @@ void bar() {
 	}
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
-	<rule name="ClassCastExceptionWithToArray"
+    <rule name="ClassCastExceptionWithToArray"
           language="java"
           since="3.4"
           message="This usage of the Collection.toArray() method will throw a ClassCastException."
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ClassCastExceptionWithToArray">
-  <description>
-When deriving an array of a specific class from your Collection, one should provide an array of
-the same class as the parameter of the toArray() method. Doing otherwise you will will result
-in a ClassCastException.
-  </description>
-  <priority>3</priority>
-  <properties>
-    <property name="xpath">
-    <value>
-<![CDATA[
+        <description>
+            When deriving an array of a specific class from your Collection, one should provide an
+            array of
+            the same class as the parameter of the toArray() method. Doing otherwise you will will
+            result
+            in a ClassCastException.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //CastExpression[Type/ReferenceType/ClassOrInterfaceType[@Image !=
 "Object"]]/PrimaryExpression
 [
@@ -317,11 +328,11 @@ and
 count(PrimarySuffix) = 1
 ]
 ]]>
-    </value>
-    </property>
-  </properties>
-  <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 Collection c = new ArrayList();
 Integer obj = new Integer(1);
 c.add(obj);
@@ -332,32 +343,37 @@ Integer[] a = (Integer [])c.toArray();
    // this is fine and will not trigger the rule
 Integer[] b = (Integer [])c.toArray(new Integer[c.size()]);
 ]]>
-  </example>
-</rule>
+        </example>
+    </rule>
 
 
-<rule  name="AvoidDecimalLiteralsInBigDecimalConstructor"
-       language="java"
-       since="3.4"
-       message="Avoid creating BigDecimal with a decimal (float/double) literal. Use a String literal"
-       class="net.sourceforge.pmd.lang.rule.XPathRule"
-       externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidDecimalLiteralsInBigDecimalConstructor">
-  <description>
-One might assume that the result of "new BigDecimal(0.1)" is exactly equal to 0.1, but it is actually
-equal to .1000000000000000055511151231257827021181583404541015625.
-This is because 0.1 cannot be represented exactly as a double (or as a binary fraction of any finite
-length). Thus, the long value that is being passed in to the constructor is not exactly equal to 0.1,
-appearances notwithstanding.
+    <rule name="AvoidDecimalLiteralsInBigDecimalConstructor"
+          language="java"
+          since="3.4"
+          message="Avoid creating BigDecimal with a decimal (float/double) literal. Use a String literal"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidDecimalLiteralsInBigDecimalConstructor">
+        <description>
+            One might assume that the result of "new BigDecimal(0.1)" is exactly equal to 0.1, but
+            it is actually
+            equal to .1000000000000000055511151231257827021181583404541015625.
+            This is because 0.1 cannot be represented exactly as a double (or as a binary fraction
+            of any finite
+            length). Thus, the long value that is being passed in to the constructor is not exactly
+            equal to 0.1,
+            appearances notwithstanding.
 
-The (String) constructor, on the other hand, is perfectly predictable: 'new BigDecimal("0.1")' is
-exactly equal to 0.1, as one would expect.  Therefore, it is generally recommended that the
-(String) constructor be used in preference to this one.
-  </description>
-  <priority>3</priority>
-  <properties>
-    <property name="xpath">
-    <value>
-<![CDATA[
+            The (String) constructor, on the other hand, is perfectly predictable: 'new
+            BigDecimal("0.1")' is
+            exactly equal to 0.1, as one would expect. Therefore, it is generally recommended that
+            the
+            (String) constructor be used in preference to this one.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //AllocationExpression
 [ClassOrInterfaceType[@Image="BigDecimal"]]
 [Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix
@@ -378,36 +394,37 @@ exactly equal to 0.1, as one would expect.  Therefore, it is generally recommend
     ]
 ]
  ]]>
-    </value>
-    </property>
-  </properties>
-  <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 BigDecimal bd = new BigDecimal(1.123);		// loss of precision, this would trigger the rule
 
 BigDecimal bd = new BigDecimal("1.123");   	// preferred approach
 
 BigDecimal bd = new BigDecimal(12);     	// preferred approach, ok for integer values
 ]]>
-  </example>
-</rule>
+        </example>
+    </rule>
 
 
-    <rule  name="MisplacedNullCheck"
-    	   language="java"
-           since="3.5"
-           message="The null check here is misplaced; if the variable is null there will be a NullPointerException"
-           class="net.sourceforge.pmd.lang.rule.XPathRule"
-           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#MisplacedNullCheck">
-      <description>
-The null check here is misplaced. If the variable is null a NullPointerException will be thrown.
-Either the check is useless (the variable will never be "null") or it is incorrect.
-      </description>
-      <priority>3</priority>
-      <properties>
-        <property name="xpath">
-        <value>
-    <![CDATA[
+    <rule name="MisplacedNullCheck"
+          language="java"
+          since="3.5"
+          message="The null check here is misplaced; if the variable is null there will be a NullPointerException"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#MisplacedNullCheck">
+        <description>
+            The null check here is misplaced. If the variable is null a NullPointerException will be
+            thrown.
+            Either the check is useless (the variable will never be "null") or it is incorrect.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //Expression
     /*[self::ConditionalOrExpression or self::ConditionalAndExpression]
     /descendant::PrimaryExpression/PrimaryPrefix
@@ -426,19 +443,19 @@ Either the check is useless (the variable will never be "null") or it is incorre
       ) = 0
      ]
     ]]>
-        </value>
-        </property>
-      </properties>
-      <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 	void bar() {
 		if (a.equals(baz) && a != null) {}
 		}
 }
     ]]>
-      </example>
-      <example><![CDATA[
+        </example>
+        <example><![CDATA[
 public class Foo {
 	void bar() {
 		if (a.equals(baz) || a == null) {}
@@ -448,30 +465,31 @@ public class Foo {
     </rule>
 
 
-    <rule  name="AvoidThreadGroup"
-    	   language="java"
-           since="3.6"
-           message="Avoid using java.lang.ThreadGroup; it is not thread safe"
-           class="net.sourceforge.pmd.lang.rule.XPathRule"
-           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidThreadGroup"
-           typeResolution="true">
-      <description>
-Avoid using java.lang.ThreadGroup; although it is intended to be used in a threaded environment
-it contains methods that are not thread-safe.
-      </description>
-      <priority>3</priority>
-      <properties>
-        <property name="xpath">
-        <value>
-<![CDATA[
+    <rule name="AvoidThreadGroup"
+          language="java"
+          since="3.6"
+          message="Avoid using java.lang.ThreadGroup; it is not thread safe"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidThreadGroup"
+          typeResolution="true">
+        <description>
+            Avoid using java.lang.ThreadGroup; although it is intended to be used in a threaded
+            environment
+            it contains methods that are not thread-safe.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //AllocationExpression/ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.ThreadGroup')]|
 //PrimarySuffix[contains(@Image, 'getThreadGroup')]
 ]]>
-        </value>
-        </property>
-      </properties>
-      <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Bar {
 	void buz() {
 		ThreadGroup tg = new ThreadGroup("My threadgroup") ;
@@ -481,7 +499,7 @@ public class Bar {
 	}
 }
     ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="BrokenNullCheck"
@@ -490,12 +508,12 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.basic.BrokenNullCheckRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BrokenNullCheck">
         <description>
-The null check is broken since it will throw a NullPointerException itself.
-It is likely that you used || instead of &amp;&amp; or vice versa.
-     </description>
+            The null check is broken since it will throw a NullPointerException itself.
+            It is likely that you used || instead of &amp;&amp; or vice versa.
+        </description>
         <priority>2</priority>
         <example>
-<![CDATA[
+            <![CDATA[
 public String bar(String string) {
   // should be &&
 	if (string!=null || !string.equals(""))
@@ -513,73 +531,76 @@ public String bar(String string) {
           message="Don't create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
           class="net.sourceforge.pmd.lang.java.rule.basic.BigIntegerInstantiationRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#BigIntegerInstantiation">
-  <description>
-Don't create instances of already existing BigInteger (BigInteger.ZERO, BigInteger.ONE) and
-for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN)
-  </description>
-  <priority>3</priority>
-  <example>
-<![CDATA[
+        <description>
+            Don't create instances of already existing BigInteger (BigInteger.ZERO, BigInteger.ONE)
+            and
+            for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal.ONE,
+            BigDecimal.TEN)
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
 BigInteger bi = new BigInteger(1);		// reference BigInteger.ONE instead
 BigInteger bi2 = new BigInteger("0");	// reference BigInteger.ZERO instead
 BigInteger bi3 = new BigInteger(0.0);	// reference BigInteger.ZERO instead
 BigInteger bi4;
 bi4 = new BigInteger(0);				// reference BigInteger.ZERO instead
 ]]>
-  </example>
-</rule>
+        </example>
+    </rule>
 
-    <rule   name="AvoidUsingOctalValues"
-            since="3.9"
-            message="Do not start a literal by 0 unless it's an octal value"
-            class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingOctalValuesRule"
-            externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingOctalValues">
-    <description>
-    	<![CDATA[
+    <rule name="AvoidUsingOctalValues"
+          since="3.9"
+          message="Do not start a literal by 0 unless it's an octal value"
+          class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingOctalValuesRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingOctalValues">
+        <description>
+            <![CDATA[
 Integer literals should not start with zero since this denotes that the rest of literal will be
 interpreted as an octal value.
     	]]>
-    </description>
-    <priority>3</priority>
-    <example>
-		    <![CDATA[
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
 int i = 012;	// set i with 10 not 12
 int j = 010;	// set j with 8 not 10
 k = i * j;		// set k with 80 not 120
 		    ]]>
-    </example>
+        </example>
     </rule>
 
-    <rule   name="AvoidUsingHardCodedIP"
-            since="4.1"
-            message="Do not hard code the IP address ${variableName}"
-            class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingHardCodedIPRule"
-            externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingHardCodedIP">
-	    <description>
-	    	<![CDATA[
+    <rule name="AvoidUsingHardCodedIP"
+          since="4.1"
+          message="Do not hard code the IP address ${variableName}"
+          class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingHardCodedIPRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidUsingHardCodedIP">
+        <description>
+            <![CDATA[
 Application with hard-coded IP addresses can become impossible to deploy in some cases.
 Externalizing IP adresses is preferable.
 	    	]]>
-	    </description>
-	    <priority>3</priority>
-	     <properties>
-            <property name="pattern" type="String" description="Regular Expression" value='^"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"$'/>
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="pattern" type="String" description="Regular Expression"
+                      value='^"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"$'/>
         </properties>
-	    <example>
-	    <![CDATA[
+        <example>
+            <![CDATA[
 public class Foo {
 	private String ip = "127.0.0.1"; 	// not recommended
 }
 	    ]]>
-	    </example>
+        </example>
     </rule>
 
-  <rule name="CheckResultSet"
-    	language="java"
-        since="4.1"
-        class="net.sourceforge.pmd.lang.java.rule.basic.CheckResultSetRule"
-        message="Always check the return of one of the navigation method (next,previous,first,last) of a ResultSet."
-        externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckResultSet">
+    <rule name="CheckResultSet"
+          language="java"
+          since="4.1"
+          class="net.sourceforge.pmd.lang.java.rule.basic.CheckResultSetRule"
+          message="Always check the return of one of the navigation method (next,previous,first,last) of a ResultSet."
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckResultSet">
         <description>
             <![CDATA[
 Always check the return values of navigation methods (next, previous, first, last) of a ResultSet.
@@ -605,10 +626,10 @@ if (rst.next()) {	// result is properly examined and used
         </example>
     </rule>
 
-	<rule name="AvoidMultipleUnaryOperators"
-		  since="4.2"
-		  class="net.sourceforge.pmd.lang.java.rule.basic.AvoidMultipleUnaryOperatorsRule"
-		  message="Using multiple unary operators may be a bug, and/or is confusing."
+    <rule name="AvoidMultipleUnaryOperators"
+          since="4.2"
+          class="net.sourceforge.pmd.lang.java.rule.basic.AvoidMultipleUnaryOperatorsRule"
+          message="Using multiple unary operators may be a bug, and/or is confusing."
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidMultipleUnaryOperators">
         <description>
             <![CDATA[
@@ -640,41 +661,43 @@ int j = -~7;
         </example>
     </rule>
 
-  <rule name="ExtendsObject"
-  		language="java"
-        since="5.0"
-        message="No need to explicitly extend Object."
-        class="net.sourceforge.pmd.lang.rule.XPathRule"
-        externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ExtendsObject">
-    <description>No need to explicitly extend Object.</description>
-    <priority>4</priority>
-    <properties>
-       <property name="xpath">
-          <value>
-          <![CDATA[
+    <rule name="ExtendsObject"
+          language="java"
+          since="5.0"
+          message="No need to explicitly extend Object."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#ExtendsObject">
+        <description>No need to explicitly extend Object.</description>
+        <priority>4</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //ExtendsList/ClassOrInterfaceType[@Image='Object' or @Image='java.lang.Object']
           ]]>
-          </value>
-       </property>
-    </properties>
-    <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo extends Object { 	// not required
 }
     ]]>
-    </example>
-  </rule>
+        </example>
+    </rule>
 
-	<rule name="CheckSkipResult"
-	      language="java"
-	  	  since="5.0"
+    <rule name="CheckSkipResult"
+          language="java"
+          since="5.0"
           message="Check the value returned by the skip() method of an InputStream to see if the requested number of bytes has been skipped."
           class="net.sourceforge.pmd.lang.java.rule.basic.CheckSkipResultRule"
-	  	  externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckSkipResult">
-        <description>The skip() method may skip a smaller number of bytes than requested. Check the returned value to find out if it was the case or not.</description>
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#CheckSkipResult">
+        <description>The skip() method may skip a smaller number of bytes than requested. Check the
+            returned value to find out if it was the case or not.
+        </description>
         <priority>3</priority>
         <example>
-        <![CDATA[
+            <![CDATA[
 public class Foo {
 
    private FileInputStream _s = new FileInputStream("file");
@@ -695,10 +718,10 @@ public class Foo {
         </example>
     </rule>
 
-	<rule name="AvoidBranchingStatementAsLastInLoop"
-	  	  since="5.0"
-		  class="net.sourceforge.pmd.lang.java.rule.basic.AvoidBranchingStatementAsLastInLoopRule"
-		  message="Avoid using a branching statement as the last in a loop."
+    <rule name="AvoidBranchingStatementAsLastInLoop"
+          since="5.0"
+          class="net.sourceforge.pmd.lang.java.rule.basic.AvoidBranchingStatementAsLastInLoopRule"
+          message="Avoid using a branching statement as the last in a loop."
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#AvoidBranchingStatementAsLastInLoop">
         <description>
             <![CDATA[
@@ -727,20 +750,21 @@ for (int i = 0; i < 10; i++) {
         </example>
     </rule>
 
-    <rule  name="DontCallThreadRun"
-           language="java"
-           since="4.3"
-           message="Don't call Thread.run() explicitly, use Thread.start()"
-           class="net.sourceforge.pmd.lang.rule.XPathRule"
-           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontCallThreadRun">
-      <description>
-Explicitly calling Thread.run() method will execute in the caller's thread of control.  Instead, call Thread.start() for the intended behavior.
-      </description>
-      <priority>4</priority>
-      <properties>
-        <property name="xpath">
-          <value>
-<![CDATA[
+    <rule name="DontCallThreadRun"
+          language="java"
+          since="4.3"
+          message="Don't call Thread.run() explicitly, use Thread.start()"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontCallThreadRun">
+        <description>
+            Explicitly calling Thread.run() method will execute in the caller's thread of control.
+            Instead, call Thread.start() for the intended behavior.
+        </description>
+        <priority>4</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //StatementExpression/PrimaryExpression
 [
     PrimaryPrefix
@@ -754,42 +778,42 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
     ]
 ]
 ]]>
-         </value>
-        </property>
-      </properties>
-      <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 Thread t = new Thread();
 t.run();            // use t.start() instead
 new Thread().run(); // same violation
 ]]>
-      </example>
+        </example>
     </rule>
 
-  <rule  name="DontUseFloatTypeForLoopIndices"
-         language="java"
-         since="4.3"
-         message="Don't use floating point for loop indices. If you must use floating point, use double."
-         class="net.sourceforge.pmd.lang.rule.XPathRule"
-         externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontUseFloatTypeForLoopIndices">
-    <description>
-Don't use floating point for loop indices. If you must use floating point, use double
-unless you're certain that float provides enough precision and you have a compelling
-performance need (space or time).
-    </description>
-    <priority>3</priority>
-    <properties>
-      <property name="xpath">
-        <value>
-<![CDATA[
+    <rule name="DontUseFloatTypeForLoopIndices"
+          language="java"
+          since="4.3"
+          message="Don't use floating point for loop indices. If you must use floating point, use double."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#DontUseFloatTypeForLoopIndices">
+        <description>
+            Don't use floating point for loop indices. If you must use floating point, use double
+            unless you're certain that float provides enough precision and you have a compelling
+            performance need (space or time).
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //ForStatement/ForInit/LocalVariableDeclaration
 /Type/PrimitiveType[@Image="float"]
 ]]>
-       </value>
-      </property>
-    </properties>
-    <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Count {
   public static void main(String[] args) {
     final int START = 2000000000;
@@ -802,7 +826,7 @@ public class Count {
     }
 }
 ]]>
-    </example>
-  </rule>
+        </example>
+    </rule>
 
 </ruleset>

--- a/support-pmd/src/main/resources/empty.xml
+++ b/support-pmd/src/main/resources/empty.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<ruleset name="Empty Code"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+The Empty Code ruleset contains rules that find empty statements of any kind (empty method,
+empty block statement, empty try or catch block,...).
+  </description>
+
+ <rule name="EmptyCatchBlock"
+  		  language="java"
+  	  	  since="0.1"
+          message="Avoid empty catch blocks"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyCatchBlock">
+      <description>
+Empty Catch Block finds instances where an exception is caught, but nothing is done.  
+In most circumstances, this swallows an exception which should either be acted on 
+or reported.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+    <![CDATA[
+//CatchStatement
+ [count(Block/BlockStatement) = 0 and ($allowCommentedBlocks != 'true' or Block/@containsComment = 'false')]
+ [FormalParameter/Type/ReferenceType
+   /ClassOrInterfaceType[@Image != 'InterruptedException' and @Image != 'CloneNotSupportedException']
+ ]
+ ]]>
+             </value>
+          </property>
+          <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="true"/>
+      </properties>
+      <example>
+  <![CDATA[
+public void doSomething() {
+  try {
+    FileInputStream fis = new FileInputStream("/tmp/bugger");
+  } catch (IOException ioe) {
+      // not good
+  }
+}
+ ]]>
+      </example>
+    </rule>
+
+    <rule name="EmptyIfStmt"
+    		 language="java"
+    		 since="0.1"
+          message="Avoid empty 'if' statements"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyIfStmt">
+      <description>
+Empty If Statement finds instances where a condition is checked but nothing is done about it.
+    </description>
+        <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//IfStatement/Statement
+ [EmptyStatement or Block[count(*) = 0]]
+ ]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+    <![CDATA[
+public class Foo {
+ void bar(int x) {
+  if (x == 0) {
+   // empty!
+  }
+ }
+}
+ ]]>
+       </example>
+    </rule>
+
+
+    <rule name="EmptyWhileStmt"
+    		 language="java"
+    		 since="0.2"
+          message="Avoid empty 'while' statements"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyWhileStmt">
+       <description>
+Empty While Statement finds all instances where a while statement does nothing.  
+If it is a timing loop, then you should use Thread.sleep() for it; if it is
+a while loop that does a lot in the exit expression, rewrite it to make it clearer.
+       </description>
+       <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//WhileStatement/Statement[./Block[count(*) = 0]  or ./EmptyStatement]
+]]>
+              </value>
+          </property>
+      </properties>
+       <example>
+  <![CDATA[
+void bar(int a, int b) {
+	while (a == b) {
+	// empty!
+	}
+}
+ ]]>
+       </example>
+    </rule>
+
+
+    <rule name="EmptyTryBlock"
+    		 language="java"
+    		 since="0.4"
+          message="Avoid empty try blocks"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyTryBlock">
+      <description>
+Avoid empty try blocks - what's the point?
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//TryStatement/Block[1][count(*) = 0]
+]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+  <![CDATA[
+public class Foo {
+ public void bar() {
+  try {
+  } catch (Exception e) {
+    e.printStackTrace();
+  }
+ }
+}
+]]>
+      </example>
+    </rule>
+
+    <rule name="EmptyFinallyBlock"
+    		 language="java"
+    		 since="0.4"
+          message="Avoid empty finally blocks"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyFinallyBlock">
+      <description>
+Empty finally blocks serve no purpose and should be removed.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//FinallyStatement[count(Block/BlockStatement) = 0]
+ ]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+  <![CDATA[
+public class Foo {
+ public void bar() {
+  try {
+    int x=2;
+   } finally {
+    // empty!
+   }
+ }
+}
+ ]]>
+      </example>
+    </rule>
+
+
+    <rule name="EmptySwitchStatements"
+    		 language="java"
+    		 since="1.0"
+          message="Avoid empty switch statements"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptySwitchStatements">
+      <description>
+Empty switch statements serve no purpose and should be removed.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//SwitchStatement[count(*) = 1]
+ ]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+  <![CDATA[
+public void bar() {
+	int x = 2;
+	switch (x) {
+	// once there was code here
+	// but it's been commented out or something
+	}
+}
+]]>
+      </example>
+      </rule>
+
+    <rule name="EmptySynchronizedBlock"
+    		 language="java"
+    		 since="1.3"
+          message="Avoid empty synchronized blocks"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptySynchronizedBlock">
+      <description>
+Empty synchronized blocks serve no purpose and should be removed.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+<![CDATA[
+//SynchronizedStatement/Block[1][count(*) = 0]
+]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+<![CDATA[
+public class Foo {
+ public void bar() {
+  synchronized (this) {
+   // empty!
+  }
+ }
+}
+]]>
+      </example>
+    </rule>
+
+
+    <rule name="EmptyStatementNotInLoop"
+    		 language="java"
+    		 since="1.5"
+          message="An empty statement (semicolon) not part of a loop"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStatementNotInLoop">
+       <description>
+An empty statement (or a semicolon by itself) that is not used as the sole body of a 'for' 
+or 'while' loop is probably a bug.  It could also be a double semicolon, which has no purpose
+and should be removed.
+       </description>
+       <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//EmptyStatement
+ [not(
+       ../../../ForStatement
+       or ../../../WhileStatement
+       or ../../../BlockStatement/ClassOrInterfaceDeclaration
+       or ../../../../../../ForStatement/Statement[1]
+        /Block[1]/BlockStatement[1]/Statement/EmptyStatement
+       or ../../../../../../WhileStatement/Statement[1]
+        /Block[1]/BlockStatement[1]/Statement/EmptyStatement)
+ ]
+]]>
+                </value>
+            </property>
+        </properties>
+       <example>
+<![CDATA[
+public void doit() {
+      // this is probably not what you meant to do
+      ;
+      // the extra semicolon here this is not necessary
+      System.out.println("look at the extra semicolon");;
+}
+]]>
+       </example>
+     </rule>
+
+<rule 	name="EmptyInitializer"
+		    language="java"
+	  		since="5.0"   	
+          	message="Empty initializer was found"
+          	class="net.sourceforge.pmd.lang.rule.XPathRule"
+          	externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyInitializer">
+       <description>
+Empty initializers serve no purpose and should be removed.
+       </description>
+       <priority>3</priority>
+         <properties>
+             <property name="xpath">
+                 <value>
+<![CDATA[
+//Initializer/Block[count(*)=0]
+]]>
+                 </value>
+             </property>
+         </properties>
+       <example>
+   <![CDATA[
+public class Foo {
+
+   static {} // Why ?
+
+   {} // Again, why ?
+
+}
+    ]]>
+    </example>
+  </rule>
+
+  <rule name="EmptyStatementBlock"
+        language="java"
+        since="5.0"
+        message="Avoid empty block statements."
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+	externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStatementBlock">
+    <description>
+Empty block statements serve no purpose and should be removed.
+	</description>
+    <priority>3</priority>
+    <properties>
+       <property name="xpath">
+          <value>
+          <![CDATA[
+//BlockStatement/Statement/Block[count(*) = 0]
+          ]]>
+          </value>
+       </property>
+    </properties>
+    <example>
+    <![CDATA[
+public class Foo {
+
+   private int _bar;
+
+   public void setBar(int bar) {
+      { _bar = bar; } // Why not?
+      {} // But remove this.
+   }
+
+}
+    ]]>
+    </example>
+  </rule>
+
+    <rule name="EmptyStaticInitializer"
+    		 language="java"
+    		  since="1.5"
+           message="Empty static initializer was found"
+           class="net.sourceforge.pmd.lang.rule.XPathRule"
+           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStaticInitializer">
+       <description>
+An empty static initializer serve no purpose and should be removed.
+       </description>
+       <priority>3</priority>
+         <properties>
+             <property name="xpath">
+                 <value>
+<![CDATA[
+//Initializer[@Static='true']/Block[count(*)=0]
+]]>
+                 </value>
+             </property>
+         </properties>
+       <example>
+   <![CDATA[
+public class Foo {
+	static {
+	// empty
+	}
+}
+]]>
+       </example>
+     </rule>
+
+</ruleset>

--- a/support-pmd/src/main/resources/empty.xml
+++ b/support-pmd/src/main/resources/empty.xml
@@ -18,6 +18,7 @@
         The Empty Code ruleset contains rules that find empty statements of any kind (empty method,
         empty block statement, empty try or catch block,...).
     </description>
+    <exclude-pattern>.*/target/.*</exclude-pattern>
 
     <rule name="EmptyCatchBlock"
           language="java"

--- a/support-pmd/src/main/resources/empty.xml
+++ b/support-pmd/src/main/resources/empty.xml
@@ -11,42 +11,43 @@
  *
  **/ -->
 <ruleset name="Empty Code"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <description>
-The Empty Code ruleset contains rules that find empty statements of any kind (empty method,
-empty block statement, empty try or catch block,...).
-  </description>
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        The Empty Code ruleset contains rules that find empty statements of any kind (empty method,
+        empty block statement, empty try or catch block,...).
+    </description>
 
- <rule name="EmptyCatchBlock"
-  		  language="java"
-  	  	  since="0.1"
+    <rule name="EmptyCatchBlock"
+          language="java"
+          since="0.1"
           message="Avoid empty catch blocks"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyCatchBlock">
-      <description>
-Empty Catch Block finds instances where an exception is caught, but nothing is done.  
-In most circumstances, this swallows an exception which should either be acted on 
-or reported.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-    <![CDATA[
+        <description>
+            Empty Catch Block finds instances where an exception is caught, but nothing is done.
+            In most circumstances, this swallows an exception which should either be acted on
+            or reported.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //CatchStatement
  [count(Block/BlockStatement) = 0 and ($allowCommentedBlocks != 'true' or Block/@containsComment = 'false')]
  [FormalParameter/Type/ReferenceType
    /ClassOrInterfaceType[@Image != 'InterruptedException' and @Image != 'CloneNotSupportedException']
  ]
  ]]>
-             </value>
-          </property>
-          <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="true"/>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+            <property name="allowCommentedBlocks" type="Boolean"
+                      description="Empty blocks containing comments will be skipped" value="true"/>
+        </properties>
+        <example>
+            <![CDATA[
 public void doSomething() {
   try {
     FileInputStream fis = new FileInputStream("/tmp/bugger");
@@ -55,31 +56,32 @@ public void doSomething() {
   }
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="EmptyIfStmt"
-    		 language="java"
-    		 since="0.1"
+          language="java"
+          since="0.1"
           message="Avoid empty 'if' statements"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyIfStmt">
-      <description>
-Empty If Statement finds instances where a condition is checked but nothing is done about it.
-    </description>
+        <description>
+            Empty If Statement finds instances where a condition is checked but nothing is done
+            about it.
+        </description>
         <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //IfStatement/Statement
  [EmptyStatement or Block[count(*) = 0]]
  ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
  void bar(int x) {
   if (x == 0) {
@@ -88,64 +90,64 @@ public class Foo {
  }
 }
  ]]>
-       </example>
+        </example>
     </rule>
 
 
     <rule name="EmptyWhileStmt"
-    		 language="java"
-    		 since="0.2"
+          language="java"
+          since="0.2"
           message="Avoid empty 'while' statements"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyWhileStmt">
-       <description>
-Empty While Statement finds all instances where a while statement does nothing.  
-If it is a timing loop, then you should use Thread.sleep() for it; if it is
-a while loop that does a lot in the exit expression, rewrite it to make it clearer.
-       </description>
-       <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Empty While Statement finds all instances where a while statement does nothing.
+            If it is a timing loop, then you should use Thread.sleep() for it; if it is
+            a while loop that does a lot in the exit expression, rewrite it to make it clearer.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //WhileStatement/Statement[./Block[count(*) = 0]  or ./EmptyStatement]
 ]]>
-              </value>
-          </property>
-      </properties>
-       <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 void bar(int a, int b) {
 	while (a == b) {
 	// empty!
 	}
 }
  ]]>
-       </example>
+        </example>
     </rule>
 
 
     <rule name="EmptyTryBlock"
-    		 language="java"
-    		 since="0.4"
+          language="java"
+          since="0.4"
           message="Avoid empty try blocks"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyTryBlock">
-      <description>
-Avoid empty try blocks - what's the point?
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Avoid empty try blocks - what's the point?
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //TryStatement/Block[1][count(*) = 0]
 ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
  public void bar() {
   try {
@@ -155,30 +157,30 @@ public class Foo {
  }
 }
 ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="EmptyFinallyBlock"
-    		 language="java"
-    		 since="0.4"
+          language="java"
+          since="0.4"
           message="Avoid empty finally blocks"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyFinallyBlock">
-      <description>
-Empty finally blocks serve no purpose and should be removed.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Empty finally blocks serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //FinallyStatement[count(Block/BlockStatement) = 0]
  ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
  public void bar() {
   try {
@@ -189,31 +191,31 @@ public class Foo {
  }
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
 
     <rule name="EmptySwitchStatements"
-    		 language="java"
-    		 since="1.0"
+          language="java"
+          since="1.0"
           message="Avoid empty switch statements"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptySwitchStatements">
-      <description>
-Empty switch statements serve no purpose and should be removed.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Empty switch statements serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //SwitchStatement[count(*) = 1]
  ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-  <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public void bar() {
 	int x = 2;
 	switch (x) {
@@ -222,30 +224,30 @@ public void bar() {
 	}
 }
 ]]>
-      </example>
-      </rule>
+        </example>
+    </rule>
 
     <rule name="EmptySynchronizedBlock"
-    		 language="java"
-    		 since="1.3"
+          language="java"
+          since="1.3"
           message="Avoid empty synchronized blocks"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptySynchronizedBlock">
-      <description>
-Empty synchronized blocks serve no purpose and should be removed.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-<![CDATA[
+        <description>
+            Empty synchronized blocks serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //SynchronizedStatement/Block[1][count(*) = 0]
 ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
  public void bar() {
   synchronized (this) {
@@ -254,26 +256,28 @@ public class Foo {
  }
 }
 ]]>
-      </example>
+        </example>
     </rule>
 
 
     <rule name="EmptyStatementNotInLoop"
-    		 language="java"
-    		 since="1.5"
+          language="java"
+          since="1.5"
           message="An empty statement (semicolon) not part of a loop"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStatementNotInLoop">
-       <description>
-An empty statement (or a semicolon by itself) that is not used as the sole body of a 'for' 
-or 'while' loop is probably a bug.  It could also be a double semicolon, which has no purpose
-and should be removed.
-       </description>
-       <priority>3</priority>
+        <description>
+            An empty statement (or a semicolon by itself) that is not used as the sole body of a
+            'for'
+            or 'while' loop is probably a bug. It could also be a double semicolon, which has no
+            purpose
+            and should be removed.
+        </description>
+        <priority>3</priority>
         <properties>
             <property name="xpath">
                 <value>
-<![CDATA[
+                    <![CDATA[
 //EmptyStatement
  [not(
        ../../../ForStatement
@@ -288,8 +292,8 @@ and should be removed.
                 </value>
             </property>
         </properties>
-       <example>
-<![CDATA[
+        <example>
+            <![CDATA[
 public void doit() {
       // this is probably not what you meant to do
       ;
@@ -297,30 +301,30 @@ public void doit() {
       System.out.println("look at the extra semicolon");;
 }
 ]]>
-       </example>
-     </rule>
+        </example>
+    </rule>
 
-<rule 	name="EmptyInitializer"
-		    language="java"
-	  		since="5.0"   	
-          	message="Empty initializer was found"
-          	class="net.sourceforge.pmd.lang.rule.XPathRule"
-          	externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyInitializer">
-       <description>
-Empty initializers serve no purpose and should be removed.
-       </description>
-       <priority>3</priority>
-         <properties>
-             <property name="xpath">
-                 <value>
-<![CDATA[
+    <rule name="EmptyInitializer"
+          language="java"
+          since="5.0"
+          message="Empty initializer was found"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyInitializer">
+        <description>
+            Empty initializers serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //Initializer/Block[count(*)=0]
 ]]>
-                 </value>
-             </property>
-         </properties>
-       <example>
-   <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 
    static {} // Why ?
@@ -329,30 +333,30 @@ public class Foo {
 
 }
     ]]>
-    </example>
-  </rule>
+        </example>
+    </rule>
 
-  <rule name="EmptyStatementBlock"
-        language="java"
-        since="5.0"
-        message="Avoid empty block statements."
-        class="net.sourceforge.pmd.lang.rule.XPathRule"
-	externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStatementBlock">
-    <description>
-Empty block statements serve no purpose and should be removed.
-	</description>
-    <priority>3</priority>
-    <properties>
-       <property name="xpath">
-          <value>
-          <![CDATA[
+    <rule name="EmptyStatementBlock"
+          language="java"
+          since="5.0"
+          message="Avoid empty block statements."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStatementBlock">
+        <description>
+            Empty block statements serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //BlockStatement/Statement/Block[count(*) = 0]
           ]]>
-          </value>
-       </property>
-    </properties>
-    <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 
    private int _bar;
@@ -364,37 +368,37 @@ public class Foo {
 
 }
     ]]>
-    </example>
-  </rule>
+        </example>
+    </rule>
 
     <rule name="EmptyStaticInitializer"
-    		 language="java"
-    		  since="1.5"
-           message="Empty static initializer was found"
-           class="net.sourceforge.pmd.lang.rule.XPathRule"
-           externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStaticInitializer">
-       <description>
-An empty static initializer serve no purpose and should be removed.
-       </description>
-       <priority>3</priority>
-         <properties>
-             <property name="xpath">
-                 <value>
-<![CDATA[
+          language="java"
+          since="1.5"
+          message="Empty static initializer was found"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/empty.html#EmptyStaticInitializer">
+        <description>
+            An empty static initializer serve no purpose and should be removed.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //Initializer[@Static='true']/Block[count(*)=0]
 ]]>
-                 </value>
-             </property>
-         </properties>
-       <example>
-   <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 	static {
 	// empty
 	}
 }
 ]]>
-       </example>
-     </rule>
+        </example>
+    </rule>
 
 </ruleset>

--- a/support-pmd/src/main/resources/sunsecure.xml
+++ b/support-pmd/src/main/resources/sunsecure.xml
@@ -18,6 +18,7 @@
         These rules check the security guidelines from Sun, published at
         http://java.sun.com/security/seccodeguide.html#gcg
     </description>
+    <exclude-pattern>.*/target/.*</exclude-pattern>
 
     <rule name="MethodReturnsInternalArray"
           since="2.2"

--- a/support-pmd/src/main/resources/sunsecure.xml
+++ b/support-pmd/src/main/resources/sunsecure.xml
@@ -11,25 +11,28 @@
  *
  **/ -->
 <ruleset name="Security Code Guidelines"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <description>
-These rules check the security guidelines from Sun, published at http://java.sun.com/security/seccodeguide.html#gcg
-  </description>
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        These rules check the security guidelines from Sun, published at
+        http://java.sun.com/security/seccodeguide.html#gcg
+    </description>
 
     <rule name="MethodReturnsInternalArray"
-    	    since="2.2"
+          since="2.2"
           message="Returning ''{0}'' may expose an internal array."
           class="net.sourceforge.pmd.lang.java.rule.sunsecure.MethodReturnsInternalArrayRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/sunsecure.html#MethodReturnsInternalArray">
-      <description>
-Exposing internal arrays to the caller violates object encapsulation since elements can be 
-removed or replaced outside of the object that owns it. It is safer to return a copy of the array.
-      </description>
+        <description>
+            Exposing internal arrays to the caller violates object encapsulation since elements can
+            be
+            removed or replaced outside of the object that owns it. It is safer to return a copy of
+            the array.
+        </description>
         <priority>3</priority>
-      <example>
-  <![CDATA[
+        <example>
+            <![CDATA[
 public class SecureSystem {
   UserData [] ud;
   public UserData [] getUserData() {
@@ -38,21 +41,21 @@ public class SecureSystem {
   }
 }
   ]]>
-      </example>
-      </rule>
+        </example>
+    </rule>
 
     <rule name="ArrayIsStoredDirectly"
-    	  since="2.2"
-        message="The user-supplied array ''{0}'' is stored directly."
+          since="2.2"
+          message="The user-supplied array ''{0}'' is stored directly."
           class="net.sourceforge.pmd.lang.java.rule.sunsecure.ArrayIsStoredDirectlyRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/sunsecure.html#ArrayIsStoredDirectly">
-      <description>
-Constructors and methods receiving arrays should clone objects and store the copy.
-This prevents future changes from the user from affecting the original array.
-      </description>
+        <description>
+            Constructors and methods receiving arrays should clone objects and store the copy.
+            This prevents future changes from the user from affecting the original array.
+        </description>
         <priority>3</priority>
-      <example>
-  <![CDATA[
+        <example>
+            <![CDATA[
 public class Foo {
   private String [] x;
     public void foo (String [] param) {
@@ -61,8 +64,8 @@ public class Foo {
     }
 }
   ]]>
-      </example>
-      </rule>
-    
+        </example>
+    </rule>
+
 </ruleset>
                                          

--- a/support-pmd/src/main/resources/sunsecure.xml
+++ b/support-pmd/src/main/resources/sunsecure.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<ruleset name="Security Code Guidelines"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+These rules check the security guidelines from Sun, published at http://java.sun.com/security/seccodeguide.html#gcg
+  </description>
+
+    <rule name="MethodReturnsInternalArray"
+    	    since="2.2"
+          message="Returning ''{0}'' may expose an internal array."
+          class="net.sourceforge.pmd.lang.java.rule.sunsecure.MethodReturnsInternalArrayRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/sunsecure.html#MethodReturnsInternalArray">
+      <description>
+Exposing internal arrays to the caller violates object encapsulation since elements can be 
+removed or replaced outside of the object that owns it. It is safer to return a copy of the array.
+      </description>
+        <priority>3</priority>
+      <example>
+  <![CDATA[
+public class SecureSystem {
+  UserData [] ud;
+  public UserData [] getUserData() {
+      // Don't return directly the internal array, return a copy
+      return ud;
+  }
+}
+  ]]>
+      </example>
+      </rule>
+
+    <rule name="ArrayIsStoredDirectly"
+    	  since="2.2"
+        message="The user-supplied array ''{0}'' is stored directly."
+          class="net.sourceforge.pmd.lang.java.rule.sunsecure.ArrayIsStoredDirectlyRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/sunsecure.html#ArrayIsStoredDirectly">
+      <description>
+Constructors and methods receiving arrays should clone objects and store the copy.
+This prevents future changes from the user from affecting the original array.
+      </description>
+        <priority>3</priority>
+      <example>
+  <![CDATA[
+public class Foo {
+  private String [] x;
+    public void foo (String [] param) {
+      // Don't do this, make a copy of the array at least
+      this.x=param;
+    }
+}
+  ]]>
+      </example>
+      </rule>
+    
+</ruleset>
+                                         

--- a/support-pmd/src/main/resources/unnecessary.xml
+++ b/support-pmd/src/main/resources/unnecessary.xml
@@ -11,48 +11,48 @@
  *
  **/ -->
 <ruleset name="Unnecessary"
-    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-  <description>
-The Unnecessary Ruleset contains a collection of rules for unnecessary code.
-  </description>
-   
-	
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        The Unnecessary Ruleset contains a collection of rules for unnecessary code.
+    </description>
+
+
     <rule name="UnnecessaryConversionTemporary"
-    		 since="0.1"
+          since="0.1"
           message="Avoid unnecessary temporaries when converting primitives to Strings"
           class="net.sourceforge.pmd.lang.java.rule.unnecessary.UnnecessaryConversionTemporaryRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryConversionTemporary">
-      <description>
-Avoid the use temporary objects when converting primitives to Strings. Use the static conversion methods
-on the wrapper classes instead.
-      </description>
+        <description>
+            Avoid the use temporary objects when converting primitives to Strings. Use the static
+            conversion methods
+            on the wrapper classes instead.
+        </description>
         <priority>3</priority>
-      <example>
-  <![CDATA[
+        <example>
+            <![CDATA[
 public String convert(int x) {
 	String foo = new Integer(x).toString();	// this wastes an object
 	
 	return Integer.toString(x);				// preferred approach
 }
  ]]>
-      </example>
+        </example>
     </rule>
 
 
-
     <rule name="UnnecessaryReturn"
-    		 since="1.3"
+          since="1.3"
           message="Avoid unnecessary return statements"
           class="net.sourceforge.pmd.lang.java.rule.unnecessary.UnnecessaryReturnRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryReturn">
-      <description>
-Avoid the use of unnecessary return statements.
-      </description>
-      <priority>3</priority>
-      <example>
-		<![CDATA[
+        <description>
+            Avoid the use of unnecessary return statements.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
 public class Foo {
   public void bar() {
     int x = 42;
@@ -60,33 +60,34 @@ public class Foo {
   }
 }
 		]]>
-      </example>
+        </example>
     </rule>
 
 
     <rule name="UnnecessaryFinalModifier"
-    	  language="java"
-    	  since="3.0"
+          language="java"
+          since="3.0"
           message="Unnecessary final modifier in final class"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryFinalModifier">
-      <description>
-When a class has the final modifier, all the methods are automatically final and do not need to be
-tagged as such.
-      </description>
-      <priority>3</priority>
-      <properties>
-          <property name="xpath">
-              <value>
-    <![CDATA[
+        <description>
+            When a class has the final modifier, all the methods are automatically final and do not
+            need to be
+            tagged as such.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //ClassOrInterfaceDeclaration[@Final='true' and @Interface='false']
 /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Final='true']
     ]]>
-              </value>
-          </property>
-      </properties>
-      <example>
-<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public final class Foo {
     // This final modifier is not necessary, since the class is final
     // and thus, all methods are final
@@ -95,17 +96,17 @@ public final class Foo {
 }
 
 ]]>
-      </example>
+        </example>
     </rule>
 
 
     <rule name="UselessOverridingMethod"
-    since="3.3"
-    message="Overriding method merely calls super"
-    class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOverridingMethodRule"
+          since="3.3"
+          message="Overriding method merely calls super"
+          class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOverridingMethodRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessOverridingMethod">
         <description>
-The overriding method merely calls the same method defined in a superclass.
+            The overriding method merely calls the same method defined in a superclass.
         </description>
         <priority>3</priority>
         <example><![CDATA[
@@ -124,18 +125,20 @@ public Long getId() {
         ]]></example>
     </rule>
 
-    <rule  name="UselessOperationOnImmutable"
-           since="3.5"
-           message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
-           class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOperationOnImmutableRule"
-           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessOperationOnImmutable">
-      <description>
-An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself
-since the result of the operation is a new object. Therefore, ignoring the operation result is an error.
-      </description>
-      <priority>3</priority>
-      <example>
-    <![CDATA[
+    <rule name="UselessOperationOnImmutable"
+          since="3.5"
+          message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
+          class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOperationOnImmutableRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessOperationOnImmutable">
+        <description>
+            An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the
+            object itself
+            since the result of the operation is a new object. Therefore, ignoring the operation
+            result is an error.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
 import java.math.*;
 
 class Test {
@@ -149,23 +152,24 @@ class Test {
   }
 }
     ]]>
-      </example>
+        </example>
     </rule>
 
     <rule name="UnusedNullCheckInEquals"
-    		 language="java"
-        since="3.5"
-        message="Invoke equals() on the object you''ve already ensured is not null"
-        class="net.sourceforge.pmd.lang.rule.XPathRule"
-        externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnusedNullCheckInEquals">
-    <description>
-After checking an object reference for null, you should invoke equals() on that object rather than passing it to another object's equals() method.
-    </description>
-	<priority>3</priority>
-    <properties>
-        <property name="xpath">
-        <value>
-        <![CDATA[
+          language="java"
+          since="3.5"
+          message="Invoke equals() on the object you''ve already ensured is not null"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnusedNullCheckInEquals">
+        <description>
+            After checking an object reference for null, you should invoke equals() on that object
+            rather than passing it to another object's equals() method.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 (//PrimaryPrefix[ends-with(Name/@Image, '.equals') and Name/@Image != 'Arrays.equals'] | //PrimarySuffix[@Image='equals' and not(../PrimaryPrefix/Literal)])
  /following-sibling::PrimarySuffix/Arguments/ArgumentList/Expression
  /PrimaryExpression[count(PrimarySuffix)=0]/PrimaryPrefix
@@ -174,11 +178,11 @@ After checking an object reference for null, you should invoke equals() on that 
  ./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
   /PrimaryExpression/PrimaryPrefix/Name/@Image]
         ]]>
-        </value>
-        </property>
-    </properties>
-		<example>
-		<![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Test {
 
   public String method1() { return "ok";}
@@ -215,21 +219,21 @@ public class Test {
 }
 }
 				]]>
-			</example>
-		</rule>
+        </example>
+    </rule>
 
-  <rule name="UselessParentheses"
-  		language="java"
-        since="5.0"
-        message="Useless parentheses."
-        class="net.sourceforge.pmd.lang.rule.XPathRule"
-        externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessParentheses">
-    <description>Useless parentheses should be removed.</description>
-    <priority>4</priority>
-    <properties>
-       <property name="xpath">
-          <value>
-          <![CDATA[
+    <rule name="UselessParentheses"
+          language="java"
+          since="5.0"
+          message="Useless parentheses."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessParentheses">
+        <description>Useless parentheses should be removed.</description>
+        <priority>4</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
 //Expression/PrimaryExpression/PrimaryPrefix/Expression
 [count(*)=1][count(./CastExpression)=0][count(./ConditionalExpression[@Ternary='true'])=0]
 [not(./AdditiveExpression[//Literal[@StringLiteral='true']])]
@@ -265,11 +269,11 @@ public class Test {
     count(./ConditionalAndExpression)=0 and
     count(./ConditionalOrExpression)=0]
           ]]>
-          </value>
-       </property>
-    </properties>
-    <example>
-    <![CDATA[
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
 public class Foo {
 
    private int _bar1;
@@ -282,7 +286,7 @@ public class Foo {
 
 }
     ]]>
-    </example>
-  </rule>
-  
+        </example>
+    </rule>
+
 </ruleset>

--- a/support-pmd/src/main/resources/unnecessary.xml
+++ b/support-pmd/src/main/resources/unnecessary.xml
@@ -17,6 +17,7 @@
     <description>
         The Unnecessary Ruleset contains a collection of rules for unnecessary code.
     </description>
+    <exclude-pattern>.*/target/.*</exclude-pattern>
 
 
     <rule name="UnnecessaryConversionTemporary"

--- a/support-pmd/src/main/resources/unnecessary.xml
+++ b/support-pmd/src/main/resources/unnecessary.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<ruleset name="Unnecessary"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+The Unnecessary Ruleset contains a collection of rules for unnecessary code.
+  </description>
+   
+	
+    <rule name="UnnecessaryConversionTemporary"
+    		 since="0.1"
+          message="Avoid unnecessary temporaries when converting primitives to Strings"
+          class="net.sourceforge.pmd.lang.java.rule.unnecessary.UnnecessaryConversionTemporaryRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryConversionTemporary">
+      <description>
+Avoid the use temporary objects when converting primitives to Strings. Use the static conversion methods
+on the wrapper classes instead.
+      </description>
+        <priority>3</priority>
+      <example>
+  <![CDATA[
+public String convert(int x) {
+	String foo = new Integer(x).toString();	// this wastes an object
+	
+	return Integer.toString(x);				// preferred approach
+}
+ ]]>
+      </example>
+    </rule>
+
+
+
+    <rule name="UnnecessaryReturn"
+    		 since="1.3"
+          message="Avoid unnecessary return statements"
+          class="net.sourceforge.pmd.lang.java.rule.unnecessary.UnnecessaryReturnRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryReturn">
+      <description>
+Avoid the use of unnecessary return statements.
+      </description>
+      <priority>3</priority>
+      <example>
+		<![CDATA[
+public class Foo {
+  public void bar() {
+    int x = 42;
+    return;
+  }
+}
+		]]>
+      </example>
+    </rule>
+
+
+    <rule name="UnnecessaryFinalModifier"
+    	  language="java"
+    	  since="3.0"
+          message="Unnecessary final modifier in final class"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryFinalModifier">
+      <description>
+When a class has the final modifier, all the methods are automatically final and do not need to be
+tagged as such.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="xpath">
+              <value>
+    <![CDATA[
+//ClassOrInterfaceDeclaration[@Final='true' and @Interface='false']
+/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Final='true']
+    ]]>
+              </value>
+          </property>
+      </properties>
+      <example>
+<![CDATA[
+public final class Foo {
+    // This final modifier is not necessary, since the class is final
+    // and thus, all methods are final
+    private final void foo() {
+    }
+}
+
+]]>
+      </example>
+    </rule>
+
+
+    <rule name="UselessOverridingMethod"
+    since="3.3"
+    message="Overriding method merely calls super"
+    class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOverridingMethodRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessOverridingMethod">
+        <description>
+The overriding method merely calls the same method defined in a superclass.
+        </description>
+        <priority>3</priority>
+        <example><![CDATA[
+public void foo(String bar) {
+  super.foo(bar);      // why bother overriding?
+}
+
+public String foo() {
+	return super.foo();  // why bother overriding?
+}
+
+@Id
+public Long getId() {
+  return super.getId();  // OK if 'ignoreAnnotations' is false, which is the default behavior
+}
+        ]]></example>
+    </rule>
+
+    <rule  name="UselessOperationOnImmutable"
+           since="3.5"
+           message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
+           class="net.sourceforge.pmd.lang.java.rule.unnecessary.UselessOperationOnImmutableRule"
+           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessOperationOnImmutable">
+      <description>
+An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself
+since the result of the operation is a new object. Therefore, ignoring the operation result is an error.
+      </description>
+      <priority>3</priority>
+      <example>
+    <![CDATA[
+import java.math.*;
+
+class Test {
+  void method1() {
+    BigDecimal bd=new BigDecimal(10);
+    bd.add(new BigDecimal(5)); 		// this will trigger the rule
+  }
+  void method2() {
+    BigDecimal bd=new BigDecimal(10);
+    bd = bd.add(new BigDecimal(5)); // this won't trigger the rule
+  }
+}
+    ]]>
+      </example>
+    </rule>
+
+    <rule name="UnusedNullCheckInEquals"
+    		 language="java"
+        since="3.5"
+        message="Invoke equals() on the object you''ve already ensured is not null"
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnusedNullCheckInEquals">
+    <description>
+After checking an object reference for null, you should invoke equals() on that object rather than passing it to another object's equals() method.
+    </description>
+	<priority>3</priority>
+    <properties>
+        <property name="xpath">
+        <value>
+        <![CDATA[
+(//PrimaryPrefix[ends-with(Name/@Image, '.equals') and Name/@Image != 'Arrays.equals'] | //PrimarySuffix[@Image='equals' and not(../PrimaryPrefix/Literal)])
+ /following-sibling::PrimarySuffix/Arguments/ArgumentList/Expression
+ /PrimaryExpression[count(PrimarySuffix)=0]/PrimaryPrefix
+ /Name[@Image = ./../../../../../../../../../../Expression/ConditionalAndExpression
+ /EqualityExpression[@Image="!=" and count(./preceding-sibling::*)=0 and
+ ./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+  /PrimaryExpression/PrimaryPrefix/Name/@Image]
+        ]]>
+        </value>
+        </property>
+    </properties>
+		<example>
+		<![CDATA[
+public class Test {
+
+  public String method1() { return "ok";}
+  public String method2() { return null;}
+
+  public void method(String a) {
+    String b;
+	// I don't know it method1() can be "null"
+	// but I know "a" is not null..
+	// I'd better write a.equals(method1())
+	
+	if (a!=null && method1().equals(a)) { // will trigger the rule
+	//whatever
+	}
+	
+	if (method1().equals(a) && a != null) { // won't trigger the rule
+	//whatever
+	}
+	
+	if (a!=null && method1().equals(b)) { // won't trigger the rule
+	//whatever
+	}
+	
+	if (a!=null && "LITERAL".equals(a)) { // won't trigger the rule
+	//whatever
+	}
+	
+	if (a!=null && !a.equals("go")) { // won't trigger the rule
+	a=method2();
+	if (method1().equals(a)) {
+	//whatever
+	}
+  }
+}
+}
+				]]>
+			</example>
+		</rule>
+
+  <rule name="UselessParentheses"
+  		language="java"
+        since="5.0"
+        message="Useless parentheses."
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessParentheses">
+    <description>Useless parentheses should be removed.</description>
+    <priority>4</priority>
+    <properties>
+       <property name="xpath">
+          <value>
+          <![CDATA[
+//Expression/PrimaryExpression/PrimaryPrefix/Expression
+[count(*)=1][count(./CastExpression)=0][count(./ConditionalExpression[@Ternary='true'])=0]
+[not(./AdditiveExpression[//Literal[@StringLiteral='true']])]
+|
+//Expression/ConditionalAndExpression/PrimaryExpression/PrimaryPrefix/Expression[
+    count(*)=1 and
+    count(./CastExpression)=0 and
+    count(./EqualityExpression/MultiplicativeExpression)=0 and
+    count(./ConditionalOrExpression)=0]
+|
+//Expression/ConditionalOrExpression/PrimaryExpression/PrimaryPrefix/Expression[
+    count(*)=1 and
+    count(./CastExpression)=0 and
+    count(./EqualityExpression/MultiplicativeExpression)=0]
+|
+//Expression/ConditionalExpression/PrimaryExpression/PrimaryPrefix/Expression[
+    count(*)=1 and
+    count(./CastExpression)=0 and
+    count(./EqualityExpression)=0]
+|
+//Expression/AdditiveExpression[not(./PrimaryExpression/PrimaryPrefix/Literal[@StringLiteral = 'true'])]/PrimaryExpression[1]/PrimaryPrefix/Expression[
+    count(*)=1 and
+    not(./CastExpression) and
+    not(./ConditionalExpression) and
+    not(./ShiftExpression)]
+|
+//Expression/EqualityExpression/PrimaryExpression/PrimaryPrefix/Expression[
+    count(*)=1 and
+    count(./CastExpression)=0 and
+    count(./AndExpression)=0 and
+    count(./InclusiveOrExpression)=0 and
+    count(./ExclusiveOrExpression)=0 and
+    count(./ConditionalAndExpression)=0 and
+    count(./ConditionalOrExpression)=0]
+          ]]>
+          </value>
+       </property>
+    </properties>
+    <example>
+    <![CDATA[
+public class Foo {
+
+   private int _bar1;
+   private Integer _bar2;
+
+   public void setBar(int n) {
+      _bar1 = Integer.valueOf((n)); // here
+      _bar2 = (n); // and here
+   }
+
+}
+    ]]>
+    </example>
+  </rule>
+  
+</ruleset>


### PR DESCRIPTION
```
 - Added support-pmd under DDF-Parent.  I put it here instead of DDF-Support because there is a plan to merge DDF-Support into DDF-Parent in the near future.
 - Added four rulesets (basic, empty, sunsecure, and unnecessary)
 - Setup the ddf-parent pom file with a default config for pmd, using the four rulesets and setting the failOnViolation flag to false for the time being.
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/11)

<!-- Reviewable:end -->
