### PR TITLE
DDF-1184 Updating to use profile, moving version to property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 
     <groupId>ddf</groupId>
     <artifactId>ddf-parent</artifactId>
-    <!-- Must MANUALLY maven pmd plugin's support-pmd dependency version if this changes -->
     <version>3.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF Parent</name>
@@ -155,6 +154,9 @@
         <!-- Must MANUALLY update this if the ddf/support project's version changes -->
         <ddf.support.checkstyle.version>2.3.1-SNAPSHOT</ddf.support.checkstyle.version>
 
+        <!-- Must MANUALLY update this if the ddf/support-pmd project's version changes -->
+        <ddf.support.pmd.version>3.0.1-SNAPSHOT</ddf.support.pmd.version>
+
         <!-- Do NOT set karaf.data or karaf.base -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -217,15 +219,13 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.4</version>
                     <dependencies>
                         <dependency>
                             <groupId>ddf</groupId>
                             <artifactId>support-pmd</artifactId>
-                            <!-- Must MANUALLY be updated if ddf-parent version changes -->
-                            <version>3.0.1-SNAPSHOT</version>
+                            <version>${ddf.support.pmd.version}</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -544,6 +544,19 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>pmd</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>bundleSource</id>
             <build>


### PR DESCRIPTION
- Added pmd profile to build, so pmd is activated by default.  Now we don't need to specify it elsewhere.
- Moved the version of support pmd into a property, so it can be easily found and easily modified by command line.
- Also removed specification of org.apache.maven.plugin as the groupId, as that is assumed by default.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/16)

<!-- Reviewable:end -->
