### PR TITLE
DDF-1320: Removing dependency on GraphViz for JavaDoc, fixing JavaDoc Profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -150,6 +150,9 @@
 
         <!-- Do NOT set karaf.data or karaf.base -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- ouput directory for reports -->
+        <project.report.output.directory>project-info</project.report.output.directory>
 
         <!-- Properties for the frontend-maven-plugin -->
         <node.version>v0.10.30</node.version>
@@ -421,6 +424,7 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <bottom><![CDATA[This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License<a>.]]> </bottom>
                         <failOnError>false</failOnError>
                         <aggregate>true</aggregate>
                         <show>protected</show>
@@ -631,7 +635,7 @@
             <activation>
     	       <file>
                   <exists>${basedir}/src/assembly/bin.xml</exists>
-               </file> 
+               </file>
 	    </activation>
 		<properties>
                 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -850,7 +854,6 @@
                                 </execution>
                             </executions>
                         </plugin>
-                        
                     </plugins>
                 </pluginManagement>
             </build>
@@ -878,8 +881,8 @@
                                 <phase>pre-site</phase>
                                 <configuration>
                                     <failOnError>false</failOnError>
-                                    <outputDirectory>${project.build.directory}/project-info/</outputDirectory>
-                                    <reportOutputDirectory>${project.reporting.outputDirectory}/project-info/
+                                    <outputDirectory>${project.build.directory}/{project.report.output.directory}/</outputDirectory>
+                                    <reportOutputDirectory>${project.reporting.outputDirectory}/{project.report.output.directory}/
                                     </reportOutputDirectory>
                                     <destDir>api</destDir>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -409,11 +409,6 @@
                     <version>0.8.0</version>
                 </plugin>
 
-                <!-- In order for the diagrams to be included within the javadocs, Graphviz
-                        must be installed and on the command line path. No spaces must exist in the
-                        path. Last known version to work with build is 2.26.3.
-                        http://www.graphviz.org/pub/graphviz/stable/ -->
-
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.7</version>
@@ -426,23 +421,9 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <failOnError>false</failOnError>
                         <aggregate>true</aggregate>
                         <show>protected</show>
-                        <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
-                        <docletArtifact>
-                            <groupId>org.umlgraph</groupId>
-                            <artifactId>doclet</artifactId>
-                            <version>5.1</version>
-                        </docletArtifact>
-                        <additionalparam>
-                            -inferrel -attributes -types -visibility
-                            -inferdep
-                            -operations -enumconstants
-                            -quiet -hide java.*
-                            -collapsible
-                            -collpackages java.util.*
-                            -postfixpackage
-                        </additionalparam>
                     </configuration>
                 </plugin>
 
@@ -642,56 +623,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-            </build>
-        </profile>
-
-        <!-- Added to allow UML Javadocs to be created on Macs that
-         are running JDK6 and/or tools.jar is not accessible.
-         jdk tools.jar is required for the new umlgraph doclet to work (5.6.6)-->
-
-        <profile>
-            <id>jdk6</id>
-            <activation>
-                <jdk>1.6</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.7</version>
-                            <executions>
-                                <execution>
-                                    <id>attach-javadocs</id>
-                                    <goals>
-                                        <goal>jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                            <configuration>
-                                <aggregate>true</aggregate>
-                                <show>protected</show>
-                                <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
-                                <docletArtifact>
-                                    <groupId>org.umlgraph</groupId>
-                                    <artifactId>doclet</artifactId>
-                                    <version>5.1</version>
-                                </docletArtifact>
-                                <additionalparam>
-                                    -inferrel -attributes -types -visibility
-                                    -inferdep
-                                    -operations -enumconstants
-                                    -quiet -hide java.*
-                                    -collapsible
-                                    -collpackages java.util.*
-                                    -postfixpackage
-                                    -nodefontsize 9
-                                    -nodefontpackagesize 7
-                                </additionalparam>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
 
@@ -946,6 +877,7 @@
                                 </goals>
                                 <phase>pre-site</phase>
                                 <configuration>
+                                    <failOnError>false</failOnError>
                                     <outputDirectory>${project.build.directory}/project-info/</outputDirectory>
                                     <reportOutputDirectory>${project.reporting.outputDirectory}/project-info/
                                     </reportOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -431,8 +431,8 @@
                         <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
                         <docletArtifact>
                             <groupId>org.umlgraph</groupId>
-                            <artifactId>umlgraph</artifactId>
-                            <version>5.6.6</version>
+                            <artifactId>doclet</artifactId>
+                            <version>5.1</version>
                         </docletArtifact>
                         <additionalparam>
                             -inferrel -attributes -types -visibility
@@ -672,7 +672,6 @@
                                 <aggregate>true</aggregate>
                                 <show>protected</show>
                                 <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
-                                <!-- This version of the doclet does not run on JDK 1.7 -->
                                 <docletArtifact>
                                     <groupId>org.umlgraph</groupId>
                                     <artifactId>doclet</artifactId>
@@ -947,8 +946,8 @@
                                 </goals>
                                 <phase>pre-site</phase>
                                 <configuration>
-                                    <outputDirectory>${project.build.directory}/docs/</outputDirectory>
-                                    <reportOutputDirectory>${project.reporting.outputDirectory}/docs/
+                                    <outputDirectory>${project.build.directory}/project-info/</outputDirectory>
+                                    <reportOutputDirectory>${project.reporting.outputDirectory}/project-info/
                                     </reportOutputDirectory>
                                     <destDir>api</destDir>
                                 </configuration>
@@ -960,15 +959,10 @@
             <reporting>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-project-info-reports-plugin</artifactId>
-                        <version>2.7</version>
-                        <reportSets>
-                            <reportSet>
-                                <reports>
-                                </reports>
-                            </reportSet>
-                        </reportSets>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
                     </plugin>
                 </plugins>
             </reporting>


### PR DESCRIPTION
- Switched from umlgraph to doclet.
- Changed output directory to be under project-information/api.
- Updated javadoc profile to skip checkstyle.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/30)

<!-- Reviewable:end -->
