### PR TITLE
DDF-1292 Added maven profile 'reports-all', added site information in distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
         <!-- Properties for the frontend-maven-plugin -->
         <node.version>v0.10.30</node.version>
         <npm.version>1.4.12</npm.version>
+
+        <!-- Set this to true to generate reports (javadoc, owasp, etc.) for deployment -->
+        <generate.all.reports>false</generate.all.reports>
     </properties>
 
     <!--
@@ -779,31 +782,14 @@
         </profile>
 
         <profile>
-            <id>reports-all</id>
+            <id>owasp</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>generate.all.reports</name>
+                </property>
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>generate-javadocs</id>
-                                <goals>
-                                    <goal>aggregate</goal>
-                                </goals>
-                                <phase>pre-site</phase>
-                                <configuration>
-                                    <failOnError>false</failOnError>
-                                    <outputDirectory>${project.build.directory}/${project.report.output.directory}/</outputDirectory>
-                                    <reportOutputDirectory>${project.reporting.outputDirectory}/${project.report.output.directory}/
-                                    </reportOutputDirectory>
-                                    <destDir>api</destDir>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
@@ -855,14 +841,12 @@
             </reporting>
         </profile>
 
-        <!--
-          This profile contains settings for producing javadocs for site deployment. Site deployment can be overridden
-          by specifying <ddf.site.repo> within .m2/settings.xml
-        -->
         <profile>
-            <id>javadoc-site</id>
+            <id>javadoc</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>generate.all.reports</name>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -897,9 +881,6 @@
                     </plugin>
                 </plugins>
             </reporting>
-            <properties>
-                <ddf.site.repo>dav:http://artifacts.codice.org/content/sites/ddf-site/</ddf.site.repo>
-            </properties>
         </profile>
 
         <profile>
@@ -959,58 +940,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>owasp</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>1.2.9</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ddf.support</groupId>
-                                <artifactId>support-owasp</artifactId>
-                                <version>${ddf.support.version}</version>
-                            </dependency>
-                        </dependencies>
-                        <configuration>
-                            <failBuildOnCVSS>7</failBuildOnCVSS>
-                            <format>ALL</format>
-                            <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-            <reporting>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>1.2.9</version>
-                        <reportSets>
-                            <reportSet>
-                                <reports>
-                                    <report>aggregate</report>
-                                </reports>
-                            </reportSet>
-                        </reportSets>
-                    </plugin>
-                </plugins>
-            </reporting>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <!--  default URL properties -->
         <ddf.scm.connection.url />
         <snapshots.repository.url />
+        <reports.repository.url />
 
         <!-- Must MANUALLY update this if the ddf/support project's version changes -->
         <ddf.support.version>2.3.4-SNAPSHOT</ddf.support.version>
@@ -90,6 +91,10 @@
             <id>releases</id>
             <url>${releases.repository.url}</url>
         </repository>
+        <site>
+            <id>reports</id>
+            <url>${reports.repository.url}</url>
+        </site>
     </distributionManagement>
 
     <build>
@@ -356,6 +361,9 @@
                         <execution>
                             <id>default-report</id>
                             <phase>prepare-package</phase>
+                            <configuration>
+                                <outputDirectory>${project.build.directory}/site/${project.report.output.directory}/jacoco/</outputDirectory>
+                            </configuration>
                             <goals>
                                 <goal>report</goal>
                             </goals>
@@ -770,6 +778,83 @@
             </build>
         </profile>
 
+        <profile>
+            <id>reports-all</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadocs</id>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <phase>pre-site</phase>
+                                <configuration>
+                                    <failOnError>false</failOnError>
+                                    <outputDirectory>${project.build.directory}/${project.report.output.directory}/</outputDirectory>
+                                    <reportOutputDirectory>${project.reporting.outputDirectory}/${project.report.output.directory}/
+                                    </reportOutputDirectory>
+                                    <destDir>api</destDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.2.9</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>ddf.support</groupId>
+                                <artifactId>support-owasp</artifactId>
+                                <version>${ddf.support.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <format>ALL</format>
+                            <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.2.9</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+
         <!--
           This profile contains settings for producing javadocs for site deployment. Site deployment can be overridden
           by specifying <ddf.site.repo> within .m2/settings.xml
@@ -792,8 +877,8 @@
                                 <phase>pre-site</phase>
                                 <configuration>
                                     <failOnError>false</failOnError>
-                                    <outputDirectory>${project.build.directory}/{project.report.output.directory}/</outputDirectory>
-                                    <reportOutputDirectory>${project.reporting.outputDirectory}/{project.report.output.directory}/
+                                    <outputDirectory>${project.build.directory}/${project.report.output.directory}/</outputDirectory>
+                                    <reportOutputDirectory>${project.reporting.outputDirectory}/${project.report.output.directory}/
                                     </reportOutputDirectory>
                                     <destDir>api</destDir>
                                 </configuration>


### PR DESCRIPTION
- Added site information to distribution management.  Couldn't get the mvn site to pull this variable correctly from the settings.xml, so we'll have to set it from the command line in Bamboo.
- Added a new profile 'reports-all' which will aggregate the owasp reports as well as the javadocs.  The jacoco plugin doesn't have a builtin way to aggregate, so that will have to be done at a later time.
- Updated the folder where jacoco reports are being generated when building (site/project-info/jacoco).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/32)

<!-- Reviewable:end -->
