### PR TITLE
DDF-1341 Updating javadoc, owasp profiles, adding release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,6 @@
         <node.version>v0.10.30</node.version>
         <npm.version>1.4.12</npm.version>
 
-        <!-- Set this to true to generate reports (javadoc, owasp, etc.) for deployment -->
-        <generate.all.reports>false</generate.all.reports>
     </properties>
 
     <!--
@@ -782,11 +780,22 @@
         </profile>
 
         <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <distributionManagement>
+                <site>
+                    <id>reports</id>
+                    <url>${reports.repository.url}/${version}</url>
+                </site>
+            </distributionManagement>
+        </profile>
+
+        <profile>
             <id>owasp</id>
             <activation>
-                <property>
-                    <name>generate.all.reports</name>
-                </property>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
@@ -844,9 +853,7 @@
         <profile>
             <id>javadoc</id>
             <activation>
-                <property>
-                    <name>generate.all.reports</name>
-                </property>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
- Updated javadoc and owasp profiles to not activate on variable (removed generate.all.reports variable).  To use them, just activate both profiles.
- Added release profile to be used in conjunction with release.  It prefixes the site deploy with a version.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/33)

<!-- Reviewable:end -->
