### PR TITLE
DDF-1341 Updating maven site plugin to attach descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.4</version>
+                    <executions>
+                        <execution>
+                            <id>attach-descriptor</id>
+                            <goals>
+                                <goal>attach-descriptor</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
- This isn't run by default with Maven 3, so we need to explicitly call it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/34)

<!-- Reviewable:end -->
