### PR TITLE
DDF-1351

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <preparationGoals>clean verify install</preparationGoals>
-                        <arguments>-Pgenerate_uml_javadoc</arguments>
+                        <arguments>-Pjavadoc-unpack</arguments>
                         <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
@@ -353,6 +353,7 @@
                         <failOnError>false</failOnError>
                         <aggregate>true</aggregate>
                         <show>protected</show>
+                        <skip>true</skip>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
-Configured the maven-javadoc-plugin to be skipped by default
-The generate_uml_javadoc profile was renamed to javadoc-unpack

@coyotesqrl @rzwiefel @roelens8 @pklinef @tbatieConnexta

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-parent/35)

<!-- Reviewable:end -->
